### PR TITLE
OPS-2630 Make IORunCmd more robust

### DIFF
--- a/krux/io.py
+++ b/krux/io.py
@@ -82,8 +82,10 @@ class IORunCmd(object):
 
         log.debug('Applying output filters: %s' % [r.pattern for r in filters])
 
-        # use shell param if set, otherwise use shell if we were passed a string
-        # i.e. let the shell parse the string rather than just splitting it
+        # Use shell param if set, otherwise use shell if we were passed a string
+        # so that the shell can parse it and support quoted or escaped arguments
+        # properly, such as:
+        #  cat "/var/log/foo bar.log" /var/log/baz\ .log
         if shell is None:
             shell = isinstance(command, basestring)
 


### PR DESCRIPTION
Exposes the `shell` parameter to Popen. If `shell` is not specified and `command` is a string, set `shell=True` so the shell will parse the command instead of splitting it on whitespace.