### PR TITLE
check for log device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: python
 install: pip install -r requirements.pip
+script: python setup.py install
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: python
+install: pip install -r requirements.pip

--- a/krux/logging.py
+++ b/krux/logging.py
@@ -107,6 +107,7 @@ LEVELS = dict((name, getattr(logging, name.upper()))
 FORMAT = '%(asctime)s: %(name)s/%(levelname)-9s: %(message)s'
 SYSLOG_FORMAT='%(name)s: %(message)s'
 
+
 def setup(level=DEFAULT_LOG_LEVEL):
     """
     Configure the root logger for a Krux application.
@@ -115,6 +116,7 @@ def setup(level=DEFAULT_LOG_LEVEL):
     """
     assert level in LEVELS.keys(), 'Invalid log level %s' % level
     logging.basicConfig(format=FORMAT, level=LEVELS[level])
+
 
 def syslog_setup(name, syslog_facility, **kwargs):
     assert syslog_facility in logging.handlers.SysLogHandler.facility_names, 'Invalid syslog facility %s' % syslog_facility
@@ -125,7 +127,7 @@ def syslog_setup(name, syslog_facility, **kwargs):
     # device, it apparently does not exist in a docker container; at the very least, not in a Travis CI
     # build docker container. Can't use os.path.isfile() which returns False for devices.
     log_device = '/dev/log'
-    if platform.system() == 'Linux' and os.path.exists(log_device):
+    if platform.system() == 'Linux' and os.access(log_device, os.W_OK):
         handler = logging.handlers.SysLogHandler(log_device, facility=syslog_facility)
     else:
         handler = logging.handlers.SysLogHandler(facility=syslog_facility)

--- a/krux/logging.py
+++ b/krux/logging.py
@@ -90,6 +90,7 @@ from __future__ import absolute_import
 import logging
 import logging.handlers
 import platform
+import os
 
 DEFAULT_LOG_LEVEL = 'warning'
 # local7 is chosen because in a typical default syslog configuration, it is *not* logged anywhere.
@@ -120,9 +121,12 @@ def syslog_setup(name, syslog_facility, **kwargs):
     logger = logging.getLogger(name)
     # On Linux, Python defaults to logging to localhost:514; on Ubuntu, rsyslog is not configured
     # to listen on the network. On other platforms (Darwin/OS X at least), Python by default sends
-    # to syslog vi a method by which syslog is listening.
-    if platform.system() == 'Linux':
-        handler = logging.handlers.SysLogHandler('/dev/log', facility=syslog_facility)
+    # to syslog via a method by which syslog is listening. Also need to test for the existence of the
+    # device, it apparently does not exist in a docker container; at the very least, not in a Travis CI
+    # build docker container. Can't use os.path.isfile() which returns False for devices.
+    log_device = '/dev/log'
+    if platform.system() == 'Linux' and os.path.exists(log_device):
+        handler = logging.handlers.SysLogHandler(log_device, facility=syslog_facility)
     else:
         handler = logging.handlers.SysLogHandler(facility=syslog_facility)
     logger.addHandler(handler)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ REPO_URL = 'https://github.com/krux/python-krux-stdlib'
 # forget to tag!
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
-
 setup(
     name='krux-stdlib',
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'


### PR DESCRIPTION
before trying to log to it; some linux hosts, such as CI docker instances, tend to not have it.