### PR TITLE
Phan raise critical error

### DIFF
--- a/krux/cli.py
+++ b/krux/cli.py
@@ -244,7 +244,12 @@ class Application(object):
 
         self.logger.critical(err)
         self._run_exit_hooks()
-        raise CriticalApplicationError(err)
+
+        exc_info = sys.exc_info()
+        if exc_info[1] is err:
+            raise CriticalApplicationError, CriticalApplicationError(exc_info[1]), exc_info[2]
+        else:
+            raise CriticalApplicationError(err)
 
     @contextmanager
     def context(self):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -179,7 +179,7 @@ class TestApplication(TestCase):
 
     def test_raise_critical_error(self):
         """
-        krux.cli.Application executes the exit hooks, logs, and wraps the error as CriticalApplicationError
+        krux.cli.Application executes the exit hooks, logs, and wraps the error as CriticalApplicationError upon raise_critical_error call
         """
         # Mock a logger
         mock_logger = MagicMock(spec=Logger, autospec=True)
@@ -190,11 +190,13 @@ class TestApplication(TestCase):
         app.add_exit_hook(mock_hook)
 
         with self.assertRaises(cli.CriticalApplicationError):
-            e = StandardError('Test Error')
-            app.raise_critical_error(e)
+            try:
+                raise StandardError('Test Error')
+            except Exception, e:
+                app.raise_critical_error(e)
 
-            mock_hook.assert_called_once_with()
-            mock_logger.critical.assert_called_once_with(e)
+        mock_hook.assert_called_once_with()
+        mock_logger.critical.assert_called_once_with(e)
 
     @patch('krux.cli.sys.exit')
     def test_context_success(self, mock_exit):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -177,6 +177,22 @@ class TestApplication(TestCase):
 
         assert_true(mock_logger.exception.called)
 
+    def test_raise_critical_error(self):
+        # Mock a logger
+        mock_logger = MagicMock(spec=Logger, autospec=True)
+        app = cli.Application(self.__class__.__name__, logger=mock_logger)
+
+        # Add an exit hook
+        mock_hook = MagicMock(return_value=True)
+        app.add_exit_hook(mock_hook)
+
+        with self.assertRaises(cli.CriticalApplicationError):
+            e = StandardError('Test Error')
+            app.raise_critical_error(e)
+
+            mock_hook.assert_called_once_with()
+            mock_logger.critical.assert_called_once_with(e)
+
 ###
 ### Test krux.cli.Application
 ###


### PR DESCRIPTION
Unit tests for `raise_critical_error()` and `context()`. Also improved `raise_critical_error()` so that it will show the complete traceback.