### PR TITLE
Better handling of stdout/stderr log supression

### DIFF
--- a/krux/cli.py
+++ b/krux/cli.py
@@ -105,6 +105,10 @@ class Application(object):
         self.name = name
 
         ### get a CLI parser
+        ###
+        ### Since this is a functional interface, we pass along whether or not stdout logging is desired
+        ### for a particular subclass/script
+        ###
         self.parser = parser or krux.cli.get_parser(description=name, logging_stdout_default=log_to_stdout)
 
         ### get more arguments, if needed
@@ -332,6 +336,17 @@ def add_logging_args(parser, stdout_default=True):
         help='syslog facility to use '
         '(default: %(default)s).'
     )
+    ###
+    ### If logging to stdout is enabled (the default, defined by the log_to_stdout arg
+    ### in __init__(), we provide a --no-log-to-stdout cli arg to disable it.
+    ###
+    ### If our calling script or subclass chooses to disable stdout logging by default,
+    ### we instead provide a --log-to-stdout arg to enable it, for debugging etc.
+    ###
+    ### This is particularly useful for Icinga monitoring scripts, where we don't want
+    ### logging info to reach stdout during normal operation, because Icinga ingests
+    ### everything that's written there.
+    ###
     if stdout_default:
         group.add_argument(
             '--no-log-to-stdout',
@@ -403,6 +418,7 @@ def get_parser(description="Krux CLI", logging=True, stats=True, lockfile=True, 
     :keyword string description: Branding for the usage output.
     :keyword bool logging: Enable standard logging arguments.
     :keyword bool stats: Enable standard stats argument.
+    :keyword bool logging_stdout_default: Whether or not logging to stdout is enabled (affects cli args setup)
 
     All other keywords are passed verbatim to
     :py:class:`argparse.ArgumentParser`

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'


### PR DESCRIPTION
This change allows inheriting classes (eg krux_monitoring_scripts.cli) to fully choose a default behavior regarding logging...

Mainly, if the inheriting class chooses to suppress stdout logging by default, those scripts will still get a --log-to-stdout command line arg to re-enable it.

If the inheriting class doesn't explicitly disable stdout logging, all behavior (including the --no-log-to-stdout arg) remains the same.