### PR TITLE
Subprocess library update

### DIFF
--- a/krux/io.py
+++ b/krux/io.py
@@ -25,11 +25,11 @@ Usage::
 ######################
 from __future__ import absolute_import
 
-import subprocess
-
 #########################
 # Third Party Libraries #
 #########################
+
+import subprocess32
 
 ######################
 # Internal Libraries #
@@ -65,7 +65,7 @@ class IORunCmd(object):
         self.stderr     = [ ]
         self.exception  = None
 
-    def run(self, command, filters = [], shell = None):
+    def run(self, command, filters = [], shell = None, timeout = None):
         log     = self.___logger
         stats   = self.___stats
 
@@ -90,21 +90,21 @@ class IORunCmd(object):
             shell = isinstance(command, basestring)
 
         try:
-            process = subprocess.Popen(
+            process = subprocess32.Popen(
                             command,
-                            stderr = subprocess.PIPE,
-                            stdout = subprocess.PIPE,
+                            stderr = subprocess32.PIPE,
+                            stdout = subprocess32.PIPE,
                             shell = shell
                          )
 
             # Note that using communicate() buffers all output in memory and can
             # hang if the buffer is filled.
-            stdout, stderr = process.communicate()
+            stdout, stderr = process.communicate(timeout = timeout)
 
             ### set the bookkeeping variables.
             ### the exit code is set on the process; communicate doesn't provide
             ### the exit code, just the outputs. So check it here. For details:
-            ### http://docs.python.org/2.6/library/subprocess.html#subprocess.Popen
+            ### https://docs.python.org/3.3/library/subprocess.html#subprocess.Popen.communicate
             self.returncode = process.returncode
             self.ok         = False if self.returncode > 0 else True
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -24,6 +24,9 @@ tornado==3.0.1
 # for lockfiles in cli
 lockfile==0.9.1
 
+# Python 3's subprocess for newer features
+subprocess32==3.2.7
+
 # Test libraries
 coverage==3.6
 mock==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'fudge',
         'gitdb',
         'smmap',
+        'subprocess32',
     ],
     tests_require=[
         'coverage',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(
         'coverage',
         'mock',
         'nose',
-    ]
+    ],
 )

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -18,6 +18,7 @@ import sys
 # Third Party Libraries #
 #########################
 from nose.tools import assert_equal, assert_true, assert_false, raises
+from subprocess32 import TimeoutExpired
 
 ######################
 # Internal Libraries #
@@ -106,5 +107,10 @@ class TestApplication(TestCase):
         assert_false(len(cmd.stdout))
         assert_false(len(cmd.stderr))
 
+    def test_timeout(self):
+        cmd = self.io.run_cmd( command = 'sleep 30', timeout = 2 )
 
-
+        assert_false(cmd.ok)
+        assert_true(cmd.exception)
+        assert_true(isinstance(cmd.exception, TimeoutExpired))
+        assert_equal(cmd.returncode, krux.io.RUN_COMMAND_EXCEPTION_EXIT_CODE)


### PR DESCRIPTION
Instead of built-in subprocess module of Python 2.6, use the back ported version from python 3.3. Expose the timeout functionality of the new version.

Version incremented