### PR TITLE
IO subprocess timeout

### DIFF
--- a/krux/io.py
+++ b/krux/io.py
@@ -90,6 +90,12 @@ class IORunCmd(object):
         if shell is None:
             shell = isinstance(command, basestring)
 
+        # GOTCHA: If the process is created using shell, upon timeout, the shell process will be
+        # terminated but not the actual command. Use 'exec' shell keyword so that the actual command's process
+        # is terminated and prevent a false timeout.
+        if shell is True and timeout is not None:
+            command = 'exec ' + command
+
         try:
             process = subprocess32.Popen(
                 command,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.1.3'
+VERSION = '2.1.4'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -20,7 +20,7 @@ import signal
 # Third Party Libraries #
 #########################
 from nose.tools import assert_equal, assert_true, assert_false, raises
-from mock import MagicMock, patch, DEFAULT, call
+from mock import MagicMock, patch, call
 from subprocess32 import TimeoutExpired, PIPE, Popen
 
 ######################
@@ -118,11 +118,10 @@ class TestApplication(TestCase):
         """
         run_cmd re-throws a TimeoutExpired error from subprocess upon timing out
         """
+
         mock_process = MagicMock(
             communicate=MagicMock(
-                # side_effect=lambda timeout: DEFAULT if timeout is None else TimeoutExpired
-                side_effect=TimeoutExpired(self.TIMEOUT_COMMAND, self.TIMEOUT_SECOND),
-                return_value=('', '')
+                side_effect=[TimeoutExpired(self.TIMEOUT_COMMAND, self.TIMEOUT_SECOND), ('', '')]
             ),
         )
         mock_popen = MagicMock(
@@ -130,7 +129,11 @@ class TestApplication(TestCase):
         )
 
         with patch('krux.io.subprocess32.Popen', mock_popen):
-            cmd = self.io.run_cmd( command = self.TIMEOUT_COMMAND, timeout = self.TIMEOUT_SECOND, timeout_terminate_signal = self.TIMEOUT_COMMAND )
+            cmd = self.io.run_cmd(
+                command = self.TIMEOUT_COMMAND,
+                timeout = self.TIMEOUT_SECOND,
+                timeout_terminate_signal = self.TIMEOUT_COMMAND
+            )
 
             assert_false(cmd.ok)
             assert_true(cmd.exception)


### PR DESCRIPTION
Three updates to the timeout feature that was introduced in v.2.1.3:

1. There is an optional parameter that can be used to send anything other than `SIGTERM` to terminate the process upon timeout
1. The unit test for timeout is improved, mainly to make sure the signals is sent to the process upon timeout.
1. 'exec ' prefix is added to the command when `shell` and `timeout` parameters are used together to avoid confusion.