### PR TITLE
Phan logger syslog

### DIFF
--- a/krux/cli.py
+++ b/krux/cli.py
@@ -118,8 +118,7 @@ class Application(object):
         self.args = self.parser.parse_args()
 
         # the cli facility should over-ride the passed-in syslog facility
-        if self.args.syslog_facility is not None:
-            syslog_facility = self.args.syslog_facility
+        syslog_facility = self.args.syslog_facility
 
         # same idea here, the cli value should over-ride the passed-in value
         if self.args.log_to_stdout != log_to_stdout:

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -339,6 +339,7 @@ def add_logging_args(parser, stdout_default=True):
         '--no-syslog-facility',
         dest='syslog_facility',
         action='store_const',
+        default=DEFAULT_LOG_FACILITY,
         const=None,
         help='disable syslog facility',
     )

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -118,7 +118,9 @@ class Application(object):
         self.args = self.parser.parse_args()
 
         # the cli facility should over-ride the passed-in syslog facility
-        if self.args.syslog_facility is not None:
+        if not self.args.no_syslog_facility:
+            syslog_facility = None
+        elif self.args.syslog_facility is not None:
             syslog_facility = self.args.syslog_facility
 
         # same idea here, the cli value should over-ride the passed-in value
@@ -334,6 +336,13 @@ def add_logging_args(parser, stdout_default=True):
         default=None,
         help='Full-qualified path to the log file '
         '(default: %(default)s).'
+    )
+
+    group.add_argument(
+        '--no-syslog-facility',
+        action='store_true',
+        default=False,
+        help='disable syslog facility',
     )
     group.add_argument(
         '--syslog-facility',

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -118,9 +118,7 @@ class Application(object):
         self.args = self.parser.parse_args()
 
         # the cli facility should over-ride the passed-in syslog facility
-        if not self.args.no_syslog_facility:
-            syslog_facility = None
-        elif self.args.syslog_facility is not None:
+        if self.args.syslog_facility is not None:
             syslog_facility = self.args.syslog_facility
 
         # same idea here, the cli value should over-ride the passed-in value
@@ -340,8 +338,9 @@ def add_logging_args(parser, stdout_default=True):
 
     group.add_argument(
         '--no-syslog-facility',
-        action='store_true',
-        default=False,
+        dest='syslog_facility',
+        action='store_const',
+        const=None,
         help='disable syslog facility',
     )
     group.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.1.4'
+VERSION = '2.2.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -142,6 +142,22 @@ class TestApplication(TestCase):
             log_to_stdout=True,
         )
 
+    @patch('krux.cli.krux.logging.get_logger')
+    def test_no_syslog_facility(self, mock_logger):
+        app = cli.Application(
+            name=self.__class__.__name__,
+            parser=self._get_parser(args=['--no-syslog-facility'])
+        )
+
+        print app.args
+
+        mock_logger.assert_called_once_with(
+            self.__class__.__name__,
+            level=DEFAULT_LOG_LEVEL,
+            syslog_facility=None,
+            log_to_stdout=True,
+        )
+
     @patch('krux.cli.partial')
     def test_add_exit_hook(self, mock_partial):
         """

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -149,8 +149,6 @@ class TestApplication(TestCase):
             parser=self._get_parser(args=['--no-syslog-facility'])
         )
 
-        print app.args
-
         mock_logger.assert_called_once_with(
             self.__class__.__name__,
             level=DEFAULT_LOG_LEVEL,

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -29,6 +29,7 @@ from nose.tools import assert_equal, assert_true
 ######################
 from krux.stats     import DummyStatsClient
 from krux.constants import DEFAULT_LOCK_DIR
+from krux.logging   import DEFAULT_LOG_LEVEL
 
 import krux.cli as cli
 
@@ -123,6 +124,18 @@ class TestApplication(TestCase):
         assert_true(isinstance(self.app.logger, Logger))
         assert_true(isinstance(self.app.stats, DummyStatsClient))
         assert_equal(self.app._exit_hooks, [])
+
+    @patch('krux.cli.krux.logging.get_logger')
+    def test_syslog_facility(self, mock_logger):
+        self.mock_parser.return_value.parse_args.return_value.syslog_facility = 'test-syslog'
+        app = cli.Application(self.__class__.__name__)
+
+        mock_logger.assert_called_once_with(
+            self.__class__.__name__,
+            level=DEFAULT_LOG_LEVEL,
+            syslog_facility='test-syslog',
+            log_to_stdout=True,
+        )
 
     @patch('krux.cli.partial')
     def test_add_exit_hook(self, mock_partial):

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -22,13 +22,29 @@ from pprint     import pprint
 
 import krux.logging
 
-def test_get_logger():
+
+TEST_LOGGER_NAME = 'test-logger'
+
+
+def test_get_logger_basic():
     """
     Test getting a logger from krux.logging
     """
-    logger = krux.logging.get_logger(__name__)
-    assert_true(logger)
+    with patch('krux.logging.setup') as mock_setup:
+        with patch('krux.logging.syslog_setup') as mock_syslog_setup:
+            krux.logging.get_logger(TEST_LOGGER_NAME, syslog_facility=None, log_to_stdout=False)
+
+    assert_true(not mock_setup.called)
+    assert_true(not mock_syslog_setup.called)
 
 
+def test_get_logger_all():
+    """
+    Test getting a logger from krux.logging
+    """
+    with patch('krux.logging.setup') as mock_setup:
+        with patch('krux.logging.syslog_setup') as mock_syslog_setup:
+            krux.logging.get_logger(TEST_LOGGER_NAME, syslog_facility=krux.logging.DEFAULT_LOG_FACILITY, log_to_stdout=True, foo='bar')
 
-
+    mock_setup.assert_called_once_with(foo='bar')
+    mock_syslog_setup.assert_called_once_with(TEST_LOGGER_NAME, krux.logging.DEFAULT_LOG_FACILITY, foo='bar')


### PR DESCRIPTION
1. Created `--no-syslog-facility` to disable syslog logging.
1. Modified `setup()` method of `krux.cli` unit test
1. Created unit tests for `--syslog-facility` and `--no-syslog-facility` CLI arguments
1. Created basic unit tests for `krux.logging`