### PR TITLE
Disabling propagation when not logging to stdout

### DIFF
--- a/krux/logging.py
+++ b/krux/logging.py
@@ -153,6 +153,12 @@ def get_logger(name, syslog_facility=None, log_to_stdout=True, **kwargs):
     # are we logging to stdout/stderr?
     if log_to_stdout:
         setup(**kwargs)
+    else:
+        # GOTCHA: Even without setup() being called, if logging.basicConfig() is called or log level is set in
+        # any of the subclass for krux.cli, the log is printed out to stderr. In order to properly stop this,
+        # disable propagating. This will stop the logs to be propagated to the ancestor logs and get logged into
+        # stderr. Syslog will still work because that is a handler to this logger.
+        logging.getLogger(name).propagate = False
     # are we logging to syslog?
     if syslog_facility is not None:
         syslog_setup(name, syslog_facility, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.2.0'
+VERSION = '2.2.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -6,6 +6,7 @@
 Unit tests for the krux.logging module.
 """
 from __future__ import absolute_import
+import logging
 __author__ = 'Jos Boumans'
 
 #########################
@@ -28,7 +29,7 @@ TEST_LOGGER_NAME = 'test-logger'
 
 def test_get_logger_basic():
     """
-    Test getting a logger from krux.logging
+    Test getting a logger with no setup from krux.logging
     """
     with patch('krux.logging.setup') as mock_setup:
         with patch('krux.logging.syslog_setup') as mock_syslog_setup:
@@ -36,11 +37,12 @@ def test_get_logger_basic():
 
     assert_true(not mock_setup.called)
     assert_true(not mock_syslog_setup.called)
+    assert_true(not logging.getLogger(TEST_LOGGER_NAME).propagate)
 
 
 def test_get_logger_all():
     """
-    Test getting a logger from krux.logging
+    Test getting a logger with all features enabled from krux.logging
     """
     with patch('krux.logging.setup') as mock_setup:
         with patch('krux.logging.syslog_setup') as mock_syslog_setup:


### PR DESCRIPTION
When `--no-log-to-stdout` is used, nothing should be printed out to the terminal. We used to do that by not setting the log level. However, `krux-boto` sets the log level on its own to minimize the debugging logs from the boto itself. This accidentally overrides `--no-log-to-stdout` CLI argument.

To mitigate that, when `--no-log-to-stdout` is set, explicitly disable log propagation. This will stop the logs to hit the ancestor loggers, stopping them from being printed on the terminal. Any log handler attached to the application logger will still log as expected.

Refer to [StackOverflow question](http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr) on this.