### PR TITLE
krux.object.Object

### DIFF
--- a/krux/object.py
+++ b/krux/object.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from abc import ABCMeta
+
+#
+# Third party libraries
+#
+
+#
+# Internal libraries
+#
+
+from krux.logging import get_logger
+from krux.stats import get_stats
+
+
+class Object(object):
+    """
+    An abstract class to handle the common Krux coding pattern
+
+    .. seealso::  https://docs.python.org/2/library/abc.html
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, name=None, logger=None, stats=None):
+        """
+        Basic init method that sets up name, logger, and stats
+
+        :param name: Name of the application
+        :type name: str
+        :param logger: Logger, recommended to be obtained using krux.cli.Application
+        :type logger: logging.Logger
+        :param stats: Stats, recommended to be obtained using krux.cli.Application
+        :type stats: kruxstatsd.StatsClient
+        """
+
+        # Private variables, not to be used outside this module
+        self._name = name if name is not None else self.__class__.__name__
+        self._logger = logger if logger is not None else get_logger(self._name)
+        self._stats = stats if stats is not None else get_stats(prefix=self._name)

--- a/tests/unit_tests/test_object.py
+++ b/tests/unit_tests/test_object.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+
+#
+# Third party libraries
+#
+
+from mock import MagicMock, patch
+
+#
+# Internal libraries
+#
+
+from krux.object import Object
+
+
+class TestObject(Object):
+    pass
+
+
+class ObjectTest(unittest.TestCase):
+    FAKE_NAME = 'fake-application'
+
+    def test_init(self):
+        """
+        __init__() correctly uses all passed variables
+        """
+        logger = MagicMock()
+        stats = MagicMock()
+
+        app = Object(
+            name=self.FAKE_NAME,
+            logger=logger,
+            stats=stats
+        )
+
+        self.assertEqual(self.FAKE_NAME, app._name)
+        self.assertEqual(logger, app._logger)
+        self.assertEqual(stats, app._stats)
+
+    @patch('krux.object.get_logger')
+    @patch('krux.object.get_stats')
+    def test_init_no_args(self, mock_stats, mock_logger):
+        """
+        __init__() correctly generates default objects when no argument is passed
+        """
+        app = Object()
+
+        self.assertEqual(Object.__name__, app._name)
+        mock_logger.assert_called_once_with(Object.__name__)
+        self.assertEqual(mock_logger.return_value, app._logger)
+        mock_stats.assert_called_once_with(prefix=Object.__name__)
+        self.assertEqual(mock_stats.return_value, app._stats)
+
+    def test_inheritance(self):
+        app = TestObject()
+
+        self.assertEqual(TestObject.__name__, app._name)


### PR DESCRIPTION
## What does this PR do?
This PR creates an abstract class to simplify the common Krux coding pattern.

## Why is this change being made?
Because those three lines are repeated in pretty much all Krux libraries.

## Where should the reviewer start?
`krux/object.py`

## How was this tested? How can the reviewer verify your testing?
The change was manually tested on the development environment and through the unit test.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation has been updated.