### PR TITLE
don't allow shell=True in subprocess.Popen() calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.4.0'
+VERSION = '2.4.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -13,8 +13,6 @@ from unittest import TestCase
 from logging import Logger
 
 import re
-import sys
-import time
 import signal
 
 #########################

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -190,7 +190,7 @@ class TestApplication(TestCase):
 
     def test_shell_injection_semicolon(self):
         """
-        Test that a command with a $() subcommand in it fails to run.
+        Test that a command with a ; in it fails to run.
         """
         cmd = self.io.run_cmd(
             command=['ls', self.SHELL_INJECTION_SEMICOLON],

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -199,6 +199,10 @@ class TestApplication(TestCase):
         assert_false(cmd.ok)
 
     def test_quoted_file_names(self):
+        """
+        Test that when we pass in a file name that needs to be quoted, that we can
+        use that filename in a command.
+        """
 
         filename = self.QUOTED_FILE_NAME.format(self.temp_dir)
         filehandle = open(filename, 'w')


### PR DESCRIPTION
Detect shell escapes in commands called via `krux.io`.