### PR TITLE
Adding --version to krux.cli.Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to be based off of 0.8.x. That markes the beginning of the 2.x series.
     in the `doc` subdirectory. Then open `doc/github/html/index.html`
     in your favorite browser.
 
-7.  To cut a release, update the VERSION in `setup.py`, merge to the
+7.  To cut a release, update the VERSION in `krux/__init__.py`, merge to the
     `release` branch, and push to GitHub. Jenkins will build and
     upload the new version to the Krux python repository, as well as
     tagging the release in git and updating the documentation.

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.1'
+VERSION = '2.5.0'

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-# -*- coding: utf-8 -*-
+VERSION = '2.4.1'

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -64,7 +64,6 @@ from krux.constants import (
     DEFAULT_LOCK_DIR,
     DEFAULT_LOCK_TIMEOUT,
 )
-
 import krux.io
 import krux.stats
 import krux.logging
@@ -89,7 +88,16 @@ class Application(object):
 
     :argument name: name of your CLI application
     """
-    def __init__(self, name, parser=None, logger=None, lockfile=False, syslog_facility=DEFAULT_LOG_FACILITY, log_to_stdout=True):
+    def __init__(
+        self,
+        name,
+        parser=None,
+        logger=None,
+        lockfile=False,
+        syslog_facility=DEFAULT_LOG_FACILITY,
+        log_to_stdout=True,
+        version=None,
+    ):
         """
         Wraps :py:class:`object` and sets up CLI argument parsing, stats and
         logging.
@@ -102,6 +110,7 @@ class Application(object):
         """
 
         ### note our name
+
         self.name = name
 
         ### get a CLI parser
@@ -113,6 +122,9 @@ class Application(object):
 
         ### get more arguments, if needed
         self.add_cli_arguments(self.parser)
+
+        if version is not None:
+            self._add_version_argument(self.parser, version)
 
         ### and parse them
         self.args = self.parser.parse_args()
@@ -195,6 +207,15 @@ class Application(object):
 
         ### release the hook when we're done
         self.add_exit_hook( ___release_lockfile, self )
+
+    def _add_version_argument(self, parser, version):
+        group = get_group(parser, 'version')
+
+        group.add_argument(
+            '--version',
+            action='version',
+            version='%(prog)s ' + version,
+        )
 
     def add_cli_arguments(self, parser):
         """

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -124,9 +124,6 @@ class Application(object):
         ### get more arguments, if needed
         self.add_cli_arguments(self.parser)
 
-        ### Handle --version argument
-        self._version = None
-
         ### and parse them
         self.args = self.parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,15 @@
 import sys
 import os
 from setuptools import setup, find_packages
+from krux import VERSION
 
-
-# We use the version to construct the DOWNLOAD_URL.
-VERSION = '2.4.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-stdlib'
 
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
+# We use the version to construct the DOWNLOAD_URL.
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
 REQUIREMENTS = ['pystache', 'Sphinx','kruxstatsd', 'argparse', 'tornado', 'simplejson', 'GitPython', 'lockfile']

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -128,6 +128,38 @@ class TestApplication(TestCase):
         assert_true(isinstance(self.app.stats, DummyStatsClient))
         assert_equal(self.app._exit_hooks, [])
 
+    @patch('krux.cli.get_group')
+    def test_add_cli_arguments_without_version(self, mock_get_group):
+        """
+        krux.cli.Application correctly does not create --version arguments when version is not set
+        """
+        self.app._VERSIONS = {}
+
+        self.app.add_cli_arguments(None)
+
+        self.assertFalse(mock_get_group.called)
+
+    @patch('krux.cli.get_group')
+    def test_add_cli_arguments_with_version(self, mock_get_group):
+        """
+        krux.cli.Application correctly create --version arguments when version is set
+        """
+        self.app.name = 'Test Application'
+        version = '1.2.3'
+        self.app._VERSIONS = {
+            self.app.name: version,
+        }
+
+        self.app.add_cli_arguments(None)
+
+        mock_get_group.assert_called_once_with(self.app.parser, 'version')
+        mock_get_group.return_value.add_argument.assert_called_once_with(
+            '--version',
+            action='version',
+            version=' '.join([self.app.name, version]),
+        )
+
+
     @patch('krux.cli.krux.logging.get_logger')
     def test_syslog_facility(self, mock_logger):
         app = cli.Application(


### PR DESCRIPTION
## What does this PR do?
This PR provides a way to add `--version` CLI argument to all `krux.cli.Application`-inherited classes.

## Why is this change being made?
Having `--version` is a nice way to quickly check the version of the CLI application without checking the source or the package manager.

## How was this tested? How can the reviewer verify your testing?
The changes were tested manually in the development environment and via unit tests.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.