### PR TITLE
PE-2585: Incrementing version of kruxstatsd

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.0'
+VERSION = '2.5.1'

--- a/requirements.pip
+++ b/requirements.pip
@@ -8,7 +8,7 @@ pystache==0.5.4
 Sphinx==1.4.6
 
 # For stats
-kruxstatsd==0.3.0
+kruxstatsd==0.3.1
 
 # For CLI arguments
 argparse==1.4.0


### PR DESCRIPTION
## What does this PR do?
This PR increments the version of `kruxstatsd` to the latest.

## Why is this change being made?
Version 0.3.0 of `kruxstatsd` had an error in `install_requires` parameter of `setup.py` that causes version collisions. Version 0.3.1 fixes it.

## How was this tested? How can the reviewer verify your testing?
The change was tested manually in `ci-a-trusty-worker003.krxd.net` and via nosetests.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)