### PR TITLE
Capture warnings in the logs

### DIFF
--- a/krux/cli.py
+++ b/krux/cli.py
@@ -84,6 +84,7 @@ class CriticalApplicationError(StandardError):
 
 class Application(object):
     _VERSIONS = {}
+    _WARNING_LOGGER_NAME = 'py.warnings'
 
     """
     Krux base class for CLI applications
@@ -157,6 +158,10 @@ class Application(object):
 
         if lockfile:
             self.acquire_lock(lockfile)
+
+        # Many libraries uses warning module to send warnings to stderr. Let's capture them in our
+        # logging so we can control them and save them.
+        logging.captureWarnings(True)
 
     def _init_logging(self, logger, syslog_facility, log_to_stdout):
         self.logger = logger or krux.logging.get_logger(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -287,6 +287,18 @@ class TestApplication(TestCase):
 
         mock_hook.assert_called_once_with()
 
+    @patch('krux.cli.logging')
+    def test_capturewarning(self, mock_logging):
+        """
+        krux.cli.Application captures all warnings and put them in the logs
+        """
+        app = cli.Application(
+            name=self.__class__.__name__,
+            parser=self._get_parser()
+        )
+
+        mock_logging.captureWarnings.assert_called_once_with(True)
+
 ###
 ### Test krux.cli.Application
 ###


### PR DESCRIPTION
## What does this PR do?
This PR improves the `krux.cli.Application` to capture all warnings in the logs.

## Why is this change being made?
A lot of popular libraries like `urllib3` or `paramiko` raises warnings using `warnings` module. They are sent to `stderr` and get lost afterwards or create a false alarm in cron jobs. Capture those warnings in the logs so that we can control them and save them better.

## How was this tested? How can the reviewer verify your testing?
The changes were tested on the development environment.