### PR TITLE
Incrementing the patch version to fix the bug with python warnings

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.1'
+VERSION = '2.5.2'


### PR DESCRIPTION
## What does this PR do?

This PR is simply incrementing the patch version to release the python warning bug fixed in #48.

## Why is this change being made?

We want to release the fix on python warning as a new version.

## How was this tested? How can the reviewer verify your testing?

The change was tested by running `python setup.py develop` in the development environment.

## Where should the reviewer start?

`krux/__init__.py`