### PR TITLE
Adds krux.argparse standard library for CLI args.

### DIFF
--- a/krux/argparse.py
+++ b/krux/argparse.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# © 2017 Krux Digital, A Salesforce Company
+#
+"""
+This module provides utilities/extensions for the
+:py:mod:`python3:argparse` module.
+"""
+
+######################
+# Standard Libraries #
+######################
+from __future__ import absolute_import
+from argparse import Action
+
+
+class AppendOverDefault(Action):
+    """
+    Argparse Action class which behaves similar to `action='append'`,
+    but over-writes the default if and only if options are specified
+    in the arguments. Example:
+
+    >>> parser = ArgumentParser()
+    >>> parser.add_argument('--ips', action=AppendOverDefault, default=['127.0.0.1'])
+    >>> options = parser.parse_args([])
+    >>> print options.ips
+    ['127.0.0.1']
+
+    >>> options = parser.parse_args(['--ips', '1.2.3.4'])
+    >>> print options.ips
+    ['1.2.3.4']
+
+    >>> options = parser.parse_args(['--ips', '1.2.3.4', '--ips', '5.6.7.8'])
+    >>> print options.ips
+    ['1.2.3.4', '5.6.7.8']
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        if namespace.ips == self.default:
+            namespace.ips = [values]
+        else:
+            namespace.ips.append(values)

--- a/krux/argparse.py
+++ b/krux/argparse.py
@@ -33,8 +33,20 @@ class AppendOverDefault(Action):
     >>> options = parser.parse_args(['--ips', '1.2.3.4', '--ips', '5.6.7.8'])
     >>> print options.ips
     ['1.2.3.4', '5.6.7.8']
+
+    Note that just like `action='append'` this Action does not
+    de-duplicate options:
+
+    >>> options = parser.parse_args(['--ips', '1.2.3.4', '--ips', '1.2.3.4'])
+    >>> print options.ips
+    ['1.2.3.4', '1.2.3.4']
     """
     def __call__(self, parser, namespace, values, option_string=None):
+        # This will be called once per incidence of the argument being
+        # specified on the command line (and zero times if the option
+        # is NOT specified). So, for the examples in the class
+        # docstring, this code will be called zero, one, and two
+        # times, respectively.
         if getattr(namespace, self.dest) == self.default:
             setattr(namespace, self.dest, [values])
         else:

--- a/krux/argparse.py
+++ b/krux/argparse.py
@@ -35,7 +35,7 @@ class AppendOverDefault(Action):
     ['1.2.3.4', '5.6.7.8']
     """
     def __call__(self, parser, namespace, values, option_string=None):
-        if namespace.ips == self.default:
-            namespace.ips = [values]
+        if getattr(namespace, self.dest) == self.default:
+            setattr(namespace, self.dest, [values])
         else:
-            namespace.ips.append(values)
+            getattr(namespace, self.dest).append(values)

--- a/tests/unit_tests/test_argparse.py
+++ b/tests/unit_tests/test_argparse.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# © 2017 Krux Digital, A Salesforce Company
+#
+"""
+Unit tests for the krux.argparse module.
+"""
+
+######################
+# Standard Libraries #
+######################
+from __future__ import absolute_import
+from argparse import ArgumentParser
+from itertools import chain
+
+#########################
+# Third Party Libraries #
+#########################
+from nose.tools import assert_equal, assert_true
+
+######################
+# Internal Libraries #
+######################
+from krux.argparse import AppendOverDefault
+
+
+DEFAULT = ['127.0.0.1']
+
+
+def test_append_none_specified():
+    """
+    AppendOverDefault uses default when no options are specified.
+    """
+    parser = ArgumentParser()
+    parser.add_argument('--ips', action=AppendOverDefault, default=DEFAULT)
+    options = parser.parse_args([])
+
+    assert_equal(options.ips, DEFAULT)
+
+
+def test_append_one_specified():
+    """
+    AppendOverDefault overwrites the default when a single option is specified.
+    """
+    specified = '1.2.3.4'
+
+    parser = ArgumentParser()
+    parser.add_argument('--ips', action=AppendOverDefault, default=DEFAULT)
+    options = parser.parse_args(['--ips', specified])
+
+    assert_true(specified in options.ips)
+    assert_true(DEFAULT not in options.ips)
+
+
+def test_append_multiple_specified():
+    """
+    AppendOverDefault overwrites default when multiple options are specified.
+    """
+    specified = ['1.2.3.4', '5.6.7.8']
+    args = chain.from_iterable([('--ips', s) for s in specified])
+
+    parser = ArgumentParser()
+    parser.add_argument('--ips', action=AppendOverDefault, default=DEFAULT)
+    options = parser.parse_args(args)
+
+    for s in specified:
+        assert_true(s in options.ips)
+
+    assert_true(DEFAULT not in options.ips)


### PR DESCRIPTION
Adds krux.argparse for argparse utilities/extensions; the first of these
is AppendOverDefault, which is an argparse Action class that behaves
similar to `action='append'` but over-writes the default if an option is
specified on the CLI.