### PR TITLE
PE-4210: Create an environment variable fall back for CLI arguments

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.4'
+VERSION = '2.6.0'

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -50,23 +50,17 @@ import __main__
 #########################
 # Third Party Libraries #
 #########################
-from argparse import ArgumentParser
 from lockfile import FileLock, LockError, UnlockError
 
 ######################
 # Internal Libraries #
 ######################
-from krux.logging import LEVELS, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FACILITY
-from krux.constants import (
-    DEFAULT_STATSD_HOST,
-    DEFAULT_STATSD_PORT,
-    DEFAULT_STATSD_ENV,
-    DEFAULT_LOCK_DIR,
-    DEFAULT_LOCK_TIMEOUT,
-)
+from krux.logging import DEFAULT_LOG_FACILITY
+from krux.constants import DEFAULT_LOCK_TIMEOUT
 import krux.io
 import krux.stats
 import krux.logging
+from krux.parser import get_group, get_parser
 
 ####################
 # Object interface #
@@ -126,7 +120,7 @@ class Application(object):
         # Since this is a functional interface, we pass along whether or not stdout logging is desired
         # for a particular subclass/script
         #
-        self.parser = parser or krux.cli.get_parser(description=name, logging_stdout_default=log_to_stdout)
+        self.parser = parser or get_parser(description=name, logging_stdout_default=log_to_stdout)
 
         # get more arguments, if needed
         self.add_cli_arguments(self.parser)
@@ -311,178 +305,6 @@ class Application(object):
 
         # if the block finishes normally, call exit
         self.exit()
-
-
-########################
-# Functional interface #
-########################
-def get_group(parser, group_name):
-    """
-    Return an argument group based on the group name.
-
-    This will return an existing group if it exists, or create a new one.
-
-    :argument parser: :py:class:`python3:argparse.ArgumentParser` to
-                      add/retrieve the group to/from.
-
-    :argument group_name: Name of the argument group to be created/returned.
-    """
-
-    # We don't want to add an additional group if there's already a 'logging'
-    # group. Sadly, ArgumentParser doesn't provide an API for this, so we have
-    # to be naughty and access a private variable.
-    groups = [g.title for g in parser._action_groups]
-
-    if group_name in groups:
-        group = parser._action_groups[groups.index(group_name)]
-    else:
-        group = parser.add_argument_group(group_name)
-
-    return group
-
-
-def add_logging_args(parser, stdout_default=True):
-    """
-    Add logging-related command-line arguments to the given parser.
-
-    Logging arguments are added to the 'logging' argument group which is
-    created if it doesn't already exist.
-
-    :argument parser: parser instance to which the arguments will be added
-    """
-    group = get_group(parser, 'logging')
-
-    group.add_argument(
-        '--log-level',
-        default=DEFAULT_LOG_LEVEL,
-        choices=LEVELS.keys(),
-        help='Verbosity of logging. (default: %(default)s)'
-    )
-    group.add_argument(
-        '--log-file',
-        default=None,
-        help='Full-qualified path to the log file '
-        '(default: %(default)s).'
-    )
-
-    group.add_argument(
-        '--no-syslog-facility',
-        dest='syslog_facility',
-        action='store_const',
-        default=DEFAULT_LOG_FACILITY,
-        const=None,
-        help='disable syslog facility',
-    )
-    group.add_argument(
-        '--syslog-facility',
-        default=DEFAULT_LOG_FACILITY,
-        help='syslog facility to use '
-        '(default: %(default)s).'
-    )
-    #
-    # If logging to stdout is enabled (the default, defined by the log_to_stdout arg
-    # in __init__(), we provide a --no-log-to-stdout cli arg to disable it.
-    #
-    # If our calling script or subclass chooses to disable stdout logging by default,
-    # we instead provide a --log-to-stdout arg to enable it, for debugging etc.
-    #
-    # This is particularly useful for Icinga monitoring scripts, where we don't want
-    # logging info to reach stdout during normal operation, because Icinga ingests
-    # everything that's written there.
-    #
-    if stdout_default:
-        group.add_argument(
-            '--no-log-to-stdout',
-            dest='log_to_stdout',
-            default=True,
-            action='store_false',
-            help='Suppress logging to stdout/stderr '
-            '(default: %(default)s).'
-        )
-    else:
-        group.add_argument(
-            '--log-to-stdout',
-            default=False,
-            action='store_true',
-            help='Log to stdout/stderr -- useful for debugging! '
-            '(default: %(default)s).'
-        )
-
-    return parser
-
-
-def add_stats_args(parser):
-    """
-    Add stats-related command-line arguments to the given parser.
-
-    :argument parser: parser instance to which the arguments will be added
-    """
-    group = get_group(parser, 'stats')
-
-    group.add_argument(
-        '--stats',
-        default=False,
-        action='store_true',
-        help='Enable sending statistics to statsd. (default: %(default)s)'
-    )
-    group.add_argument(
-        '--stats-host',
-        default=DEFAULT_STATSD_HOST,
-        help='Statsd host to send statistics to. (default: %(default)s)'
-    )
-    group.add_argument(
-        '--stats-port',
-        default=DEFAULT_STATSD_PORT,
-        help='Statsd port to send statistics to. (default: %(default)s)'
-    )
-    group.add_argument(
-        '--stats-environment',
-        default=DEFAULT_STATSD_ENV,
-        help='Statsd environment. (default: %(default)s)'
-    )
-
-    return parser
-
-
-def add_lockfile_args(parser):
-    group = get_group(parser, 'lockfile')
-
-    group.add_argument(
-        '--lock-dir',
-        default=DEFAULT_LOCK_DIR,
-        help='Dir where lock files are stored (default: %(default)s)'
-    )
-
-    return parser
-
-
-def get_parser(description="Krux CLI", logging=True, stats=True, lockfile=True, logging_stdout_default=True, **kwargs):
-    """
-    Run setup and return an argument parser for Krux applications
-
-    :keyword string description: Branding for the usage output.
-    :keyword bool logging: Enable standard logging arguments.
-    :keyword bool stats: Enable standard stats argument.
-    :keyword bool logging_stdout_default: Whether or not logging to stdout is enabled (affects cli args setup)
-
-    All other keywords are passed verbatim to
-    :py:class:`argparse.ArgumentParser`
-    """
-    parser = ArgumentParser(description=description, **kwargs)
-
-    # standard logging arguments
-    if logging:
-        parser = add_logging_args(parser, logging_stdout_default)
-
-    # standard stats arguments
-    if stats:
-        parser = add_stats_args(parser)
-
-    # standard lockfile args
-    if lockfile:
-        parser = add_lockfile_args(parser)
-
-    return parser
 
 
 def get_script_name():

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# © 2013-2017 Krux Digital, Inc.
+# © 2013-2017 Salesforce.com, inc.
 #
 
 #

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -70,13 +70,12 @@ def add_logging_args(parser, stdout_default=True):
         '--log-level',
         default=DEFAULT_LOG_LEVEL,
         choices=LEVELS.keys(),
-        help='Verbosity of logging. (default: %(default)s)'
+        help='Verbosity of logging.'
     )
     group.add_argument(
         '--log-file',
         default=None,
-        help='Full-qualified path to the log file '
-        '(default: %(default)s).'
+        help='Full-qualified path to the log file',
     )
 
     group.add_argument(
@@ -85,13 +84,14 @@ def add_logging_args(parser, stdout_default=True):
         action='store_const',
         default=DEFAULT_LOG_FACILITY,
         const=None,
+        env_var=False,
+        add_default_help=False,
         help='disable syslog facility',
     )
     group.add_argument(
         '--syslog-facility',
         default=DEFAULT_LOG_FACILITY,
-        help='syslog facility to use '
-        '(default: %(default)s).'
+        help='syslog facility to use',
     )
     #
     # If logging to stdout is enabled (the default, defined by the log_to_stdout arg
@@ -110,17 +110,16 @@ def add_logging_args(parser, stdout_default=True):
             dest='log_to_stdout',
             default=True,
             action='store_false',
-
-            help='Suppress logging to stdout/stderr '
-            '(default: %(default)s).'
+            env_var=False,
+            help='Suppress logging to stdout/stderr',
         )
     else:
         group.add_argument(
             '--log-to-stdout',
             default=False,
             action='store_true',
-            help='Log to stdout/stderr -- useful for debugging! '
-            '(default: %(default)s).'
+            env_var=False,
+            help='Log to stdout/stderr -- useful for debugging!',
         )
 
     return parser
@@ -138,22 +137,22 @@ def add_stats_args(parser):
         '--stats',
         default=False,
         action='store_true',
-        help='Enable sending statistics to statsd. (default: %(default)s)'
+        help='Enable sending statistics to statsd.'
     )
     group.add_argument(
         '--stats-host',
         default=DEFAULT_STATSD_HOST,
-        help='Statsd host to send statistics to. (default: %(default)s)'
+        help='Statsd host to send statistics to.'
     )
     group.add_argument(
         '--stats-port',
         default=DEFAULT_STATSD_PORT,
-        help='Statsd port to send statistics to. (default: %(default)s)'
+        help='Statsd port to send statistics to.'
     )
     group.add_argument(
         '--stats-environment',
         default=DEFAULT_STATSD_ENV,
-        help='Statsd environment. (default: %(default)s)'
+        help='Statsd environment.'
     )
 
     return parser
@@ -165,7 +164,7 @@ def add_lockfile_args(parser):
     group.add_argument(
         '--lock-dir',
         default=DEFAULT_LOCK_DIR,
-        help='Dir where lock files are stored (default: %(default)s)'
+        help='Dir where lock files are stored'
     )
 
     return parser

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+# © 2013-2017 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+from __future__ import absolute_import
+
+#
+# Third party libraries
+#
+from argparse import ArgumentParser, _ArgumentGroup
+
+#
+# Internal libraries
+#
+from krux.wrapper import Wrapper
+from krux.logging import LEVELS, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FACILITY
+from krux.constants import (
+    DEFAULT_STATSD_HOST,
+    DEFAULT_STATSD_PORT,
+    DEFAULT_STATSD_ENV,
+    DEFAULT_LOCK_DIR,
+)
+
+
+def get_parser(
+    logging=True,
+    stats=True,
+    lockfile=True,
+    logging_stdout_default=True,
+    *args,
+    **kwargs
+):
+    # GOTCHA: KruxParser takes in a logger and a stats object. However, "stats" parameter is already defined
+    #         as a boolean flag. Do not change the name of that parameter and break backward compatibility.
+    # TODO: Update and clean up the parameter names so we can pass logger and stats into KruxParser.
+    parser = KruxParser(ArgumentParser(*args, **kwargs))
+
+    # standard logging arguments
+    if logging:
+        parser = add_logging_args(parser, logging_stdout_default)
+
+    # standard stats arguments
+    if stats:
+        parser = add_stats_args(parser)
+
+    # standard lockfile args
+    if lockfile:
+        parser = add_lockfile_args(parser)
+
+    return parser
+
+
+def add_logging_args(parser, stdout_default=True):
+    """
+    Add logging-related command-line arguments to the given parser.
+
+    Logging arguments are added to the 'logging' argument group which is
+    created if it doesn't already exist.
+
+    :argument parser: parser instance to which the arguments will be added
+    """
+    group = get_group(parser, 'logging')
+
+    group.add_argument(
+        '--log-level',
+        default=DEFAULT_LOG_LEVEL,
+        #env_var='LOG_LEVEL',
+        choices=LEVELS.keys(),
+        help='Verbosity of logging. (default: %(default)s)'
+    )
+    group.add_argument(
+        '--log-file',
+        default=None,
+        #env_var='LOG_FILE',
+        help='Full-qualified path to the log file '
+        '(default: %(default)s).'
+    )
+
+    group.add_argument(
+        '--no-syslog-facility',
+        dest='syslog_facility',
+        action='store_const',
+        default=DEFAULT_LOG_FACILITY,
+        const=None,
+        help='disable syslog facility',
+    )
+    group.add_argument(
+        '--syslog-facility',
+        default=DEFAULT_LOG_FACILITY,
+        #env_var='SYSLOG_FACILITY',
+        help='syslog facility to use '
+        '(default: %(default)s).'
+    )
+    #
+    # If logging to stdout is enabled (the default, defined by the log_to_stdout arg
+    # in __init__(), we provide a --no-log-to-stdout cli arg to disable it.
+    #
+    # If our calling script or subclass chooses to disable stdout logging by default,
+    # we instead provide a --log-to-stdout arg to enable it, for debugging etc.
+    #
+    # This is particularly useful for Icinga monitoring scripts, where we don't want
+    # logging info to reach stdout during normal operation, because Icinga ingests
+    # everything that's written there.
+    #
+    if stdout_default:
+        group.add_argument(
+            '--no-log-to-stdout',
+            dest='log_to_stdout',
+            default=True,
+            action='store_false',
+
+            help='Suppress logging to stdout/stderr '
+            '(default: %(default)s).'
+        )
+    else:
+        group.add_argument(
+            '--log-to-stdout',
+            default=False,
+            action='store_true',
+            help='Log to stdout/stderr -- useful for debugging! '
+            '(default: %(default)s).'
+        )
+
+    return parser
+
+
+def add_stats_args(parser):
+    """
+    Add stats-related command-line arguments to the given parser.
+
+    :argument parser: parser instance to which the arguments will be added
+    """
+    group = get_group(parser, 'stats')
+
+    group.add_argument(
+        '--stats',
+        default=False,
+        action='store_true',
+        help='Enable sending statistics to statsd. (default: %(default)s)'
+    )
+    group.add_argument(
+        '--stats-host',
+        default=DEFAULT_STATSD_HOST,
+        help='Statsd host to send statistics to. (default: %(default)s)'
+    )
+    group.add_argument(
+        '--stats-port',
+        default=DEFAULT_STATSD_PORT,
+        help='Statsd port to send statistics to. (default: %(default)s)'
+    )
+    group.add_argument(
+        '--stats-environment',
+        default=DEFAULT_STATSD_ENV,
+        help='Statsd environment. (default: %(default)s)'
+    )
+
+    return parser
+
+
+def add_lockfile_args(parser):
+    group = get_group(parser, 'lockfile')
+
+    group.add_argument(
+        '--lock-dir',
+        default=DEFAULT_LOCK_DIR,
+        help='Dir where lock files are stored (default: %(default)s)'
+    )
+
+    return parser
+
+
+def get_group(parser, group_name):
+    """
+    Return an argument group based on the group name.
+
+    This will return an existing group if it exists, or create a new one.
+
+    :argument parser: :py:class:`python3:argparse.ArgumentParser` to
+                      add/retrieve the group to/from.
+
+    :argument group_name: Name of the argument group to be created/returned.
+    """
+
+    # We don't want to add an additional group if there's already a 'logging'
+    # group. Sadly, ArgumentParser doesn't provide an API for this, so we have
+    # to be naughty and access a private variable.
+    groups = [g.title for g in parser._action_groups]
+
+    if group_name in groups:
+        group = parser._action_groups[groups.index(group_name)]
+    else:
+        group = parser.add_argument_group(group_name)
+
+    return group
+
+
+class KruxParser(Wrapper):
+    def add_argument_group(self, *args, **kwargs):
+        group = KruxGroup(wrapped=_ArgumentGroup(self, *args, **kwargs), logger=self._logger, stats=self._stats)
+        self._wrapped._action_groups.append(group)
+        return group
+
+
+class KruxGroup(Wrapper):
+    def add_argument(self, *args, **kwargs):
+        return self._wrapped.add_argument(*args, **kwargs)

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -221,6 +221,12 @@ class KruxParser(Wrapper):
         self._wrapped._action_groups.append(group)
         return group
 
+    def __eq__(self, other):
+        if not isinstance(other, KruxParser):
+            return False
+        else:
+            return other._wrapped == self._wrapped
+
 
 class KruxGroup(Wrapper):
     def __init__(self, env_var_prefix=None, *args, **kwargs):

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -7,6 +7,7 @@
 # Standard libraries
 #
 from __future__ import absolute_import
+from os import environ
 
 #
 # Third party libraries
@@ -37,7 +38,7 @@ def get_parser(
     # GOTCHA: KruxParser takes in a logger and a stats object. However, "stats" parameter is already defined
     #         as a boolean flag. Do not change the name of that parameter and break backward compatibility.
     # TODO: Update and clean up the parameter names so we can pass logger and stats into KruxParser.
-    parser = KruxParser(ArgumentParser(*args, **kwargs))
+    parser = KruxParser(wrapped=ArgumentParser(*args, **kwargs))
 
     # standard logging arguments
     if logging:
@@ -63,19 +64,17 @@ def add_logging_args(parser, stdout_default=True):
 
     :argument parser: parser instance to which the arguments will be added
     """
-    group = get_group(parser, 'logging')
+    group = get_group(parser=parser, group_name='logging', prefix=False)
 
     group.add_argument(
         '--log-level',
         default=DEFAULT_LOG_LEVEL,
-        #env_var='LOG_LEVEL',
         choices=LEVELS.keys(),
         help='Verbosity of logging. (default: %(default)s)'
     )
     group.add_argument(
         '--log-file',
         default=None,
-        #env_var='LOG_FILE',
         help='Full-qualified path to the log file '
         '(default: %(default)s).'
     )
@@ -91,7 +90,6 @@ def add_logging_args(parser, stdout_default=True):
     group.add_argument(
         '--syslog-facility',
         default=DEFAULT_LOG_FACILITY,
-        #env_var='SYSLOG_FACILITY',
         help='syslog facility to use '
         '(default: %(default)s).'
     )
@@ -134,7 +132,7 @@ def add_stats_args(parser):
 
     :argument parser: parser instance to which the arguments will be added
     """
-    group = get_group(parser, 'stats')
+    group = get_group(parser=parser, group_name='stats', prefix=False)
 
     group.add_argument(
         '--stats',
@@ -162,7 +160,7 @@ def add_stats_args(parser):
 
 
 def add_lockfile_args(parser):
-    group = get_group(parser, 'lockfile')
+    group = get_group(parser=parser, group_name='lockfile', prefix=False)
 
     group.add_argument(
         '--lock-dir',
@@ -173,7 +171,7 @@ def add_lockfile_args(parser):
     return parser
 
 
-def get_group(parser, group_name):
+def get_group(parser, group_name, prefix=None):
     """
     Return an argument group based on the group name.
 
@@ -193,18 +191,67 @@ def get_group(parser, group_name):
     if group_name in groups:
         group = parser._action_groups[groups.index(group_name)]
     else:
-        group = parser.add_argument_group(group_name)
+        group = parser.add_argument_group(title=group_name, prefix=prefix)
 
     return group
 
 
 class KruxParser(Wrapper):
-    def add_argument_group(self, *args, **kwargs):
-        group = KruxGroup(wrapped=_ArgumentGroup(self, *args, **kwargs), logger=self._logger, stats=self._stats)
+    def add_argument_group(self, prefix, *args, **kwargs):
+        group = KruxGroup(
+            wrapped=_ArgumentGroup(self, *args, **kwargs), prefix=prefix, logger=self._logger, stats=self._stats,
+        )
         self._wrapped._action_groups.append(group)
         return group
 
 
 class KruxGroup(Wrapper):
+    def __init__(self, prefix=None, *args, **kwargs):
+        """
+        Creates a wrapper around argparse._ArgumentGroup that handles some help doc automation as well as environment
+        variable fall back
+
+        :param prefix: Prefix to use for the environment variables. If set to None, uses the title
+                       of the _ArgumentGroup that this is wrapping. If set to False, does not add any prefix
+        :type prefix: str | bool
+        :param args: Ordered arguments passed directly to krux.wrapper.Wrapper.__init__()
+        :type args: list
+        :param kwargs: Keyword arguments passed directly to krux.wrapper.Wrapper.__init__()
+        :type kwargs: dict
+        """
+        # Call to the superclass to bootstrap.
+        super(KruxGroup, self).__init__(*args, **kwargs)
+
+        if prefix is None:
+            self._env_prefix = self._wrapped.title + '_'
+        elif prefix is False:
+            self._env_prefix = ''
+        else:
+            self._env_prefix = str(prefix) + '_'
+
     def add_argument(self, *args, **kwargs):
+        use_env_var = kwargs.pop('use_env_var', True)
+
+        # There must be an argument defined and it must be prefixed. (i.e. This does not handle positional arguments.)
+        if use_env_var and len(args) > 0 and args[0][0] in self.prefix_chars:
+            # Find the first long-named option
+            first_long = next((arg_name for arg_name in args if arg_name[1] in self.prefix_chars), None)
+
+            # There must be a long name or environment variable support is explicitly turned off.
+            if first_long is None:
+                raise Exception(
+                    'You must either disable the environment variable fall back or provide a long name for the option'
+                )
+
+            # Determine the key of the environment variable for this argument
+            key = first_long.lstrip(self.prefix_chars)
+            if not key:
+                raise Exception(
+                    'You must provide a valid name for the option'
+                )
+            key = (self._env_prefix + key.replace('-', '_')).upper()
+
+            # Override the default value to use the environment variable
+            kwargs['default'] = environ.get(key=key, failobj=kwargs.get('default', None))
+
         return self._wrapped.add_argument(*args, **kwargs)

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -17,7 +17,6 @@ from argparse import ArgumentParser, _ArgumentGroup
 #
 # Internal libraries
 #
-from krux.wrapper import Wrapper
 from krux.logging import LEVELS, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FACILITY
 from krux.constants import (
     DEFAULT_STATSD_HOST,
@@ -104,6 +103,8 @@ def add_logging_args(parser, stdout_default=True):
     # logging info to reach stdout during normal operation, because Icinga ingests
     # everything that's written there.
     #
+    # TODO: With the environment variable support, this use case should be handled
+    #       via the environment variable. Consider removing this in v3.0
     if stdout_default:
         group.add_argument(
             '--no-log-to-stdout',

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -219,6 +219,9 @@ class KruxParser(ArgumentParser):
 
 
 class KruxGroup(_ArgumentGroup):
+    HELP_ENV_VAR = "(env: {key})"
+    HELP_DEFAULT = "(default: {default})"
+
     def __init__(self, env_var_prefix=None, *args, **kwargs):
         """
         Creates a wrapper around argparse._ArgumentGroup that handles some help doc automation as well as environment
@@ -283,7 +286,7 @@ class KruxGroup(_ArgumentGroup):
 
             # There must be a long name or environment variable support is explicitly turned off.
             if first_long is None:
-                raise Exception(
+                raise ValueError(
                     'You must either disable the environment variable fall back or provide a long name for the option'
                 )
 
@@ -291,10 +294,11 @@ class KruxGroup(_ArgumentGroup):
                 # Determine the key of the environment variable for this argument
                 key = first_long.lstrip(self.prefix_chars)
                 if not key:
-                    raise Exception(
+                    raise ValueError(
                         'You must provide a valid name for the option'
                     )
-                key = (self._env_prefix + key.replace('-', '_')).upper()
+                # TODO: Handle all of prefix_chars, not just '-' here
+                key = (self._env_prefix + key).replace('-', '_').upper()
             else:
                 key = env_var
 
@@ -303,11 +307,11 @@ class KruxGroup(_ArgumentGroup):
 
             # Add the environment variable to the help text
             if add_env_var_help:
-                help_text_list.append("(env: {key})".format(key=key))
+                help_text_list.append(self.HELP_ENV_VAR.format(key=key))
 
         # Append the default value to the help text
         if add_default_help and is_optional_argument and "(default: " not in old_help_value:
-            help_text_list.append("(default: {default})".format(default=old_default_value))
+            help_text_list.append(self.HELP_DEFAULT.format(default=old_default_value))
 
         kwargs['help'] = ' '.join(help_text_list)
 

--- a/krux/wrapper.py
+++ b/krux/wrapper.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# © 2017 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+from __future__ import absolute_import
+from abc import ABCMeta
+
+#
+# Third party libraries
+#
+
+#
+# Internal libraries
+#
+from krux.object import Object
+
+
+class Wrapper(Object):
+    # Wrapper is an abstract class and not to be instantiated directly. It should be used by being inherited
+    __metaclass__ = ABCMeta
+
+    def __init__(self, wrapped, *args, **kwargs):
+        # Call to the superclass to bootstrap.
+        super(Wrapper, self).__init__(*args, **kwargs)
+
+        self._wrapped = wrapped
+
+    def _get_wrapper_function(self, func):
+        """
+        Returns a function to be called given a function from the wrapped class. Override this function to generate
+        a default wrapper around the function.
+
+        :example:
+            >>>class Foo(Wrapper):
+            >>>    def _get_wrapper_function(self, func):
+            >>>        def logged_function(*args, **kwargs):
+            >>>            self._logger.debug("Calling function %s with args %s and kwargs %s", func.__name__, args, kwargs)
+            >>>            return func(*args, **kwargs)
+            >>>        return logged_function
+            >>>
+            >>>foo = Foo(list)
+            >>>foo.append(1)
+            >>># Debug log: Calling function append with args [1] and kwargs {}
+
+        :param func:
+        :type func: function
+        :return: The function to be executed
+        :rtype: function
+        """
+        return func
+
+    def __getattr__(self, name):
+        """
+        Finds and returns the attribute defined in the wrapped class and not in the wrapper class.
+
+        :param name: Name of the attribute
+        :type name: str
+        :return: Value of the attribute
+        :rtype: Any
+        """
+        self._logger.debug("Attribute %s is not defined directly in this class. Looking up the wrapped object", name)
+
+        # GOTCHA: This will throw AttributeError if name is not defined in self._wrapped. This is intentional.
+        value = getattr(self._wrapped, name)
+
+        if callable(value):
+            self._logger.debug("Found function %s in the wrapped object", name)
+
+            # Currently this wrapper function does not do anything, but leave a shell here for an ex
+            return self._get_wrapper_function(value)
+        else:
+            self._logger.debug("Found value %s for the attribute %s in the wrapped object", value, name)
+            return value

--- a/krux/wrapper.py
+++ b/krux/wrapper.py
@@ -64,7 +64,10 @@ class Wrapper(Object):
         """
         self._logger.debug("Attribute %s is not defined directly in this class. Looking up the wrapped object", name)
 
-        # GOTCHA: This will throw AttributeError if name is not defined in self._wrapped. This is intentional.
+        # GOTCHA: This will throw AttributeError if name is not defined in self._wrapped. If the code got here, that
+        #         means there is no extra code added around self._wrapped with the attribute named `name`.
+        #         If self._wrapped also does not have an attribute named `name`, then it should fail with the same
+        #         exception as if you did self._wrapped.`name`. Thus, the error is purposely not handled here.
         value = getattr(self._wrapped, name)
 
         if callable(value):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -46,7 +46,7 @@ def test_get_new_group():
 
     group = cli.get_group(mock_parser, name)
 
-    mock_parser.add_argument_group.assert_called_once_with(name)
+    mock_parser.add_argument_group.assert_called_once_with(title=name, prefix=None)
     assert_equal(group, name)
 
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -46,7 +46,7 @@ def test_get_new_group():
 
     group = cli.get_group(mock_parser, name)
 
-    mock_parser.add_argument_group.assert_called_once_with(title=name, prefix=None)
+    mock_parser.add_argument_group.assert_called_once_with(title=name, env_var_prefix=None)
     assert_equal(group, name)
 
 

--- a/tests/unit_tests/test_object.py
+++ b/tests/unit_tests/test_object.py
@@ -36,7 +36,7 @@ class ObjectTest(unittest.TestCase):
 
     def test_init(self):
         """
-        __init__() correctly uses all passed variables
+        krux.object.Object.__init__() correctly uses all passed variables
         """
         logger = MagicMock()
         stats = MagicMock()
@@ -55,7 +55,7 @@ class ObjectTest(unittest.TestCase):
     @patch('krux.object.get_stats')
     def test_init_no_args(self, mock_stats, mock_logger):
         """
-        __init__() correctly generates default objects when no argument is passed
+        krux.object.Object.__init__() correctly generates default objects when no argument is passed
         """
         app = Object()
 

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# © 2017 Salesforce.com, inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+
+#
+# Third party libraries
+#
+
+from mock import MagicMock, patch, call
+
+#
+# Internal libraries
+#
+
+from krux.parser import (
+    get_parser,
+    get_group,
+    add_logging_args,
+    add_stats_args,
+    add_lockfile_args,
+    KruxParser,
+    KruxGroup,
+)
+
+
+class GetterTest(unittest.TestCase):
+    FAKE_NAME = 'fake-application'
+    FAKE_DESCRIPTION = 'fake-desc'
+
+    @patch('krux.parser.add_logging_args')
+    @patch('krux.parser.add_stats_args')
+    @patch('krux.parser.add_lockfile_args')
+    @patch('krux.parser.ArgumentParser')
+    def test_get_parser_all(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
+        """
+        krux.parser.get_parser() correctly create a KruxParser object based on the parameters
+        """
+        mock_parser_class.return_value = MagicMock()
+        mock_logging.side_effect = lambda x, y: x
+        mock_stats.side_effect = lambda x: x
+        mock_lockfile.side_effect = lambda x: x
+
+        parser = get_parser(True, True, True, True, self.FAKE_NAME, description=self.FAKE_DESCRIPTION)
+
+        # Check whether the return value is correct
+        self.assertEqual(KruxParser(wrapped=mock_parser_class.return_value), parser)
+
+        # Check whether the ArgumentParser was created properly
+        mock_parser_class.assert_called_once_with(self.FAKE_NAME, description=self.FAKE_DESCRIPTION)
+
+        # Check whether the add_x_args functions were correctly called
+        mock_logging.assert_called_once_with(parser, True)
+        mock_stats.assert_called_once_with(parser)
+        mock_lockfile.assert_called_once_with(parser)
+
+    @patch('krux.parser.add_logging_args')
+    @patch('krux.parser.add_stats_args')
+    @patch('krux.parser.add_lockfile_args')
+    @patch('krux.parser.ArgumentParser')
+    def test_get_parser_none(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
+        """
+        krux.parser.get_parser() correctly skips arguments when requested
+        """
+        mock_parser_class.return_value = MagicMock()
+
+        parser = get_parser(logging=False, stats=False, lockfile=False)
+
+        # Check whether the return value is correct
+        self.assertEqual(KruxParser(wrapped=mock_parser_class.return_value), parser)
+
+        # Check whether the ArgumentParser was created properly
+        mock_parser_class.assert_called_once_with()
+
+        # Check whether the add_x_args functions were correctly called
+        self.assertFalse(mock_logging.called)
+        self.assertFalse(mock_stats.called)
+        self.assertFalse(mock_lockfile.called)
+
+    @patch('krux.parser.add_logging_args')
+    @patch('krux.parser.add_stats_args')
+    @patch('krux.parser.add_lockfile_args')
+    @patch('krux.parser.ArgumentParser')
+    def test_get_parser_no_stdout(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
+        """
+        krux.parser.get_parser() correctly sets the default value of the --log-to-stdout CLI argument
+        """
+        mock_parser_class.return_value = MagicMock()
+        mock_logging.side_effect = lambda x, y: x
+        mock_stats.side_effect = lambda x: x
+        mock_lockfile.side_effect = lambda x: x
+
+        parser = get_parser(logging_stdout_default=False)
+
+        # Check whether the add_x_args functions were correctly called
+        mock_logging.assert_called_once_with(parser, False)

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -250,3 +250,32 @@ class AddTest(unittest.TestCase):
             call('--lock-dir', default=DEFAULT_LOCK_DIR, help='Dir where lock files are stored'),
         ]
         self.assertEqual(add_argument_calls, self._group.add_argument.call_args_list)
+
+
+class KruxParserTest(unittest.TestCase):
+    def setUp(self):
+        self._parser = KruxParser()
+
+    @patch('krux.parser.KruxGroup')
+    def test_add_argument_group(self, mock_group_class):
+        env_var_prefix = False
+        title = 'fake-title'
+
+        group = self._parser.add_argument_group(env_var_prefix=env_var_prefix, title=title)
+
+        # Check whether the return value is correct
+        self.assertEqual(mock_group_class.return_value, group)
+
+        # Check whether the KruxGroup object was created correctly
+        mock_group_class.assert_called_once_with(
+            env_var_prefix=env_var_prefix,
+            container=self._parser,
+            title=title,
+        )
+
+        # Check whether the KruxGroup object was added to the list
+        self.assertIn(mock_group_class.return_value, self._parser._action_groups)
+
+
+class KruxGroupTest(unittest.TestCase):
+    pass

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -38,7 +38,7 @@ class GetterTest(unittest.TestCase):
     @patch('krux.parser.add_logging_args')
     @patch('krux.parser.add_stats_args')
     @patch('krux.parser.add_lockfile_args')
-    @patch('krux.parser.ArgumentParser')
+    @patch('krux.parser.KruxParser')
     def test_get_parser_all(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
         """
         krux.parser.get_parser() correctly create a KruxParser object based on the parameters
@@ -51,9 +51,7 @@ class GetterTest(unittest.TestCase):
         parser = get_parser(True, True, True, True, self.FAKE_NAME, description=self.FAKE_DESCRIPTION)
 
         # Check whether the return value is correct
-        self.assertEqual(KruxParser(wrapped=mock_parser_class.return_value), parser)
-
-        # Check whether the ArgumentParser was created properly
+        self.assertEqual(mock_parser_class.return_value, parser)
         mock_parser_class.assert_called_once_with(self.FAKE_NAME, description=self.FAKE_DESCRIPTION)
 
         # Check whether the add_x_args functions were correctly called
@@ -64,7 +62,7 @@ class GetterTest(unittest.TestCase):
     @patch('krux.parser.add_logging_args')
     @patch('krux.parser.add_stats_args')
     @patch('krux.parser.add_lockfile_args')
-    @patch('krux.parser.ArgumentParser')
+    @patch('krux.parser.KruxParser')
     def test_get_parser_none(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
         """
         krux.parser.get_parser() correctly skips arguments when requested
@@ -74,7 +72,8 @@ class GetterTest(unittest.TestCase):
         parser = get_parser(logging=False, stats=False, lockfile=False)
 
         # Check whether the return value is correct
-        self.assertEqual(KruxParser(wrapped=mock_parser_class.return_value), parser)
+        self.assertEqual(mock_parser_class.return_value, parser)
+        mock_parser_class.assert_called_once_with()
 
         # Check whether the ArgumentParser was created properly
         mock_parser_class.assert_called_once_with()
@@ -85,17 +84,11 @@ class GetterTest(unittest.TestCase):
         self.assertFalse(mock_lockfile.called)
 
     @patch('krux.parser.add_logging_args')
-    @patch('krux.parser.add_stats_args')
-    @patch('krux.parser.add_lockfile_args')
-    @patch('krux.parser.ArgumentParser')
-    def test_get_parser_no_stdout(self, mock_parser_class, mock_lockfile, mock_stats, mock_logging):
+    def test_get_parser_no_stdout(self, mock_logging):
         """
         krux.parser.get_parser() correctly sets the default value of the --log-to-stdout CLI argument
         """
-        mock_parser_class.return_value = MagicMock()
         mock_logging.side_effect = lambda x, y: x
-        mock_stats.side_effect = lambda x: x
-        mock_lockfile.side_effect = lambda x: x
 
         parser = get_parser(logging_stdout_default=False)
 

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -6,20 +6,25 @@
 #
 # Standard libraries
 #
-
 from __future__ import absolute_import
 import unittest
 
 #
 # Third party libraries
 #
-
 from mock import MagicMock, patch, call
+from argparse import _ArgumentGroup, ArgumentParser
 
 #
 # Internal libraries
 #
-
+from krux.logging import LEVELS, DEFAULT_LOG_LEVEL, DEFAULT_LOG_FACILITY
+from krux.constants import (
+    DEFAULT_STATSD_HOST,
+    DEFAULT_STATSD_PORT,
+    DEFAULT_STATSD_ENV,
+    DEFAULT_LOCK_DIR,
+)
 from krux.parser import (
     get_parser,
     get_group,
@@ -94,3 +99,154 @@ class GetterTest(unittest.TestCase):
 
         # Check whether the add_x_args functions were correctly called
         mock_logging.assert_called_once_with(parser, False)
+
+    @patch('krux.parser.KruxParser')
+    def test_get_group_new(self, mock_parser_class):
+        """
+        krux.parser.get_group() correctly creates a new _ArgumentGroup object when it does not exist
+        """
+        parser = mock_parser_class.return_value
+        parser._action_groups = []
+        env_var_prefix = False
+
+        group = get_group(parser=parser, group_name=self.FAKE_NAME, env_var_prefix=env_var_prefix)
+
+        # Check whether the return value is correct
+        self.assertEqual(parser.add_argument_group.return_value, group)
+
+        # Check whether the _ArgumentGroup was created correctly
+        parser.add_argument_group.assert_called_once_with(
+            title=self.FAKE_NAME, env_var_prefix=env_var_prefix
+        )
+
+    @patch('krux.parser.KruxParser')
+    def test_get_group_existing(self, mock_parser_class):
+        """
+        krux.parser.get_group() correctly uses the existing _ArgumentGroup object
+        """
+        expected = MagicMock(title=self.FAKE_NAME)
+        parser = mock_parser_class.return_value
+        parser._action_groups = [expected, MagicMock(title='foo'), MagicMock(title='bar')]
+
+        actual = get_group(parser=parser, group_name=self.FAKE_NAME)
+
+        # Check whether the return value is correct
+        self.assertEqual(expected, actual)
+
+        # Check whether the caching worked properly
+        self.assertFalse(parser.add_argument_group.called)
+
+
+class AddTest(unittest.TestCase):
+    def setUp(self):
+        self._parser = MagicMock(spec=ArgumentParser, _action_groups=[])
+        self._group = MagicMock(spec=_ArgumentGroup)
+        self._parser.add_argument_group.return_value = self._group
+
+    def test_add_logging_args_no_stdout(self):
+        """
+        krux.parser.add_logging_args() correctly sets up an _ArgumentGroup for log related arguments
+        """
+        actual = add_logging_args(parser=self._parser)
+
+        # Check whether the return value is correct
+        self.assertEqual(self._parser, actual)
+
+        # Check whether an _ArgumentGroup was successfully created
+        self._parser.add_argument_group.assert_called_once_with(title='logging', env_var_prefix=False)
+
+        # Check whether the arguments were correctly created
+        add_argument_calls = [
+            call('--log-level', default=DEFAULT_LOG_LEVEL, choices=LEVELS.keys(), help='Verbosity of logging.'),
+            call('--log-file', default=None, help='Full-qualified path to the log file'),
+            call(
+                '--no-syslog-facility',
+                dest='syslog_facility',
+                action='store_const',
+                default=DEFAULT_LOG_FACILITY,
+                const=None,
+                env_var=False,
+                add_default_help=False,
+                help='disable syslog facility',
+            ),
+            call('--syslog-facility', default=DEFAULT_LOG_FACILITY, help='syslog facility to use'),
+            call(
+                '--no-log-to-stdout',
+                dest='log_to_stdout',
+                default=True,
+                action='store_false',
+                env_var=False,
+                help='Suppress logging to stdout/stderr',
+            ),
+        ]
+        self.assertEqual(add_argument_calls, self._group.add_argument.call_args_list)
+
+    def test_add_logging_args_yes_stdout(self):
+        """
+        krux.parser.add_logging_args() correctly disables stdout logs by default when stdout_default is set to False
+        """
+        add_logging_args(parser=self._parser, stdout_default=False)
+
+        # Check whether the arguments were correctly created
+        add_argument_calls = [
+            call('--log-level', default=DEFAULT_LOG_LEVEL, choices=LEVELS.keys(), help='Verbosity of logging.'),
+            call('--log-file', default=None, help='Full-qualified path to the log file'),
+            call(
+                '--no-syslog-facility',
+                dest='syslog_facility',
+                action='store_const',
+                default=DEFAULT_LOG_FACILITY,
+                const=None,
+                env_var=False,
+                add_default_help=False,
+                help='disable syslog facility',
+            ),
+            call('--syslog-facility', default=DEFAULT_LOG_FACILITY, help='syslog facility to use'),
+            call(
+                '--log-to-stdout',
+                default=False,
+                action='store_true',
+                env_var=False,
+                help='Log to stdout/stderr -- useful for debugging!',
+            ),
+        ]
+        self.assertEqual(add_argument_calls, self._group.add_argument.call_args_list)
+
+    def test_add_stats_args(self):
+        """
+        krux.parser.add_stats_args() correctly sets up an _ArgumentGroup for stats related arguments
+        """
+        actual = add_stats_args(parser=self._parser)
+
+        # Check whether the return value is correct
+        self.assertEqual(self._parser, actual)
+
+        # Check whether an _ArgumentGroup was successfully created
+        self._parser.add_argument_group.assert_called_once_with(title='stats', env_var_prefix=False)
+
+        # Check whether the arguments were correctly created
+        add_argument_calls = [
+            call('--stats', default=False, action='store_true', help='Enable sending statistics to statsd.'),
+            call('--stats-host', default=DEFAULT_STATSD_HOST, help='Statsd host to send statistics to.'),
+            call('--stats-port', default=DEFAULT_STATSD_PORT, help='Statsd port to send statistics to.'),
+            call('--stats-environment', default=DEFAULT_STATSD_ENV, help='Statsd environment.'),
+        ]
+        self.assertEqual(add_argument_calls, self._group.add_argument.call_args_list)
+
+    def test_add_lockfile_args(self):
+        """
+        krux.parser.add_lockfile_args() correctly sets up an _ArgumentGroup for lock file related arguments
+        """
+        actual = add_lockfile_args(parser=self._parser)
+
+        # Check whether the return value is correct
+        self.assertEqual(self._parser, actual)
+
+        # Check whether an _ArgumentGroup was successfully created
+        self._parser.add_argument_group.assert_called_once_with(title='lockfile', env_var_prefix=False)
+
+        # Check whether the arguments were correctly created
+        add_argument_calls = [
+            call('--lock-dir', default=DEFAULT_LOCK_DIR, help='Dir where lock files are stored'),
+        ]
+        self.assertEqual(add_argument_calls, self._group.add_argument.call_args_list)

--- a/tests/unit_tests/test_wrapper.py
+++ b/tests/unit_tests/test_wrapper.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# © 2017 Salesforce.com, inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+
+#
+# Third party libraries
+#
+
+from mock import MagicMock, call
+
+#
+# Internal libraries
+#
+
+from krux.wrapper import Wrapper
+
+
+class TestWrapper(Wrapper):
+    z = 3
+
+    def _get_wrapper_function(self, func):
+        def wrap(*args, **kwargs):
+            self._logger.info('Calling function %s', func.__name__)
+            return func(*args, **kwargs)
+
+        return wrap
+
+
+class TestObject(object):
+    x = 1
+
+    def y(self, value):
+        return {'Name': 'y', 'Value': value}
+
+
+class WrapperTest(unittest.TestCase):
+
+    def setUp(self):
+        self._logger = MagicMock()
+        self._stats = MagicMock()
+
+        self._object = TestObject()
+
+        self._wrapper = TestWrapper(
+            wrapped=self._object,
+            logger=self._logger,
+            stats=self._stats,
+        )
+
+    def test_init(self):
+        """
+        krux.wrapper.Wrapper.__init__() correctly uses all passed variables
+        """
+        self.assertEqual(self._object, self._wrapper._wrapped)
+
+    def test_wrapper_property(self):
+        """
+        krux.wrapper.Wrapper correctly returns the value of the wrapper's property
+        """
+        self.assertEqual(TestWrapper.z, self._wrapper.z)
+        self.assertFalse(self._logger.debug.called)
+
+    def test_wrapped_property(self):
+        """
+        krux.wrapper.Wrapper correctly falls back to the wrapped's property when it is not overriden by the wrapper
+        """
+        self.assertEqual(self._object.x, self._wrapper.x)
+
+        debug_calls = [
+            call("Attribute %s is not defined directly in this class. Looking up the wrapped object", 'x'),
+            call("Found value %s for the attribute %s in the wrapped object", self._object.x, 'x'),
+        ]
+        self.assertEqual(debug_calls, self._logger.debug.call_args_list)
+
+    def test_wrapped_function(self):
+        """
+        krux.wrapper.Wrapper correctly calls the wrapped's function when it is not overriden by the wrapper
+        """
+        value = 2
+        self.assertEqual(self._object.y(value), self._wrapper.y(value))
+
+        debug_calls = [
+            call(
+                "Attribute %s is not defined directly in this class. Looking up the wrapped object",
+                self._object.y.__name__,
+            ),
+            call("Found function %s in the wrapped object", self._object.y.__name__),
+        ]
+        self.assertEqual(debug_calls, self._logger.debug.call_args_list)
+
+    def test_get_wrapper_function(self):
+        self._wrapper.y(2)
+
+        self._logger.info.assert_called_once_with('Calling function %s', self._object.y.__name__)

--- a/tests/unit_tests/test_wrapper.py
+++ b/tests/unit_tests/test_wrapper.py
@@ -97,6 +97,9 @@ class WrapperTest(unittest.TestCase):
         self.assertEqual(debug_calls, self._logger.debug.call_args_list)
 
     def test_get_wrapper_function(self):
+        """
+        krux.wrapper.Wrapper._get_wrapper_function() correctly provides a way to wrap the wrapped's function
+        """
         self._wrapper.y(2)
 
         self._logger.info.assert_called_once_with('Calling function %s', self._object.y.__name__)


### PR DESCRIPTION
## What does this PR do?

The PR creates an environment variable fall back for CLI arguments. This would allow the arguments to be set via environment variables. The precedence is `--foo` > `ENV_FOO` > default value.

## Why is this change being made?

1. This makes things easy when we need to change the default value of an argument.
2. This makes things easy when there are lots of arguments.
3. This makes things easy when there is an argument with a long value.

## How does this PR do it?

This PR create two classes `KruxParser` and `KruxGroup` that inherit `argparse.ArgumentParser` and `argparse._ArgumentGroup`, respectively. `KruxParser` is only there to create a `KruxGroup` object instead of `argparse._ArgumentGroup` object. `KruxGroup` object hijacks the arguments and override the `default` parameter with the value from environment variables. It also augment the help text to show this functionality.

## How was this tested? How can the reviewer verify your testing?

The change was tested manually using `example.py` as well as via unit test.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/qMEeYodSOOTp6/giphy.gif)

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).