### PR TITLE
Allow override of cli.Application argv arguments on instantiation

### DIFF
--- a/example.py
+++ b/example.py
@@ -17,6 +17,12 @@ class ExampleLoggingApp(krux.cli.Application):
         # the default is to print them out to the console; setting a syslog facility
         # means messages will go to syslog with the named facility and called severity;
         # your local syslog config will need to route those messages to a file or remote syslog.
+
+        # A NOTE ON *args AND **kwargs: Our intent is to capture and pass on the arguments
+        # to parent methods, which want to use them. This is one way. Another way
+        # is to declare the arguments explicitly. There's a software maintenance cost to that, though:
+        # if parameter changes are made to a ancestor method, it may require a change
+        # to the descendant methods.
         super(ExampleLoggingApp, self).__init__(name='testloggingapp', syslog_facility='local0', *args, **kwargs)
 
     def run(self):

--- a/example.py
+++ b/example.py
@@ -9,7 +9,7 @@ class ExampleLoggingApp(krux.cli.Application):
       * a command-line option parser
       * a logger
     """
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         # the 'name' parameter is just a string/name for your script. It should be unique in your environment,
         # because stats will be emitted to statsd with that as part of the stat name.
 
@@ -17,7 +17,7 @@ class ExampleLoggingApp(krux.cli.Application):
         # the default is to print them out to the console; setting a syslog facility
         # means messages will go to syslog with the named facility and called severity;
         # your local syslog config will need to route those messages to a file or remote syslog.
-        super(ExampleLoggingApp, self).__init__(name='testloggingapp', syslog_facility='local0')
+        super(ExampleLoggingApp, self).__init__(name='testloggingapp', syslog_facility='local0', *args, **kwargs)
 
     def run(self):
         """

--- a/example.py
+++ b/example.py
@@ -9,21 +9,26 @@ class ExampleLoggingApp(krux.cli.Application):
       * a command-line option parser
       * a logger
     """
-    def __init__(self, *args, **kwargs):
-        # the 'name' parameter is just a string/name for your script. It should be unique in your environment,
-        # because stats will be emitted to statsd with that as part of the stat name.
-
-        # the syslog_facility parameter being set changes where logs get sent to;
-        # the default is to print them out to the console; setting a syslog facility
-        # means messages will go to syslog with the named facility and called severity;
-        # your local syslog config will need to route those messages to a file or remote syslog.
-
-        # A NOTE ON *args AND **kwargs: Our intent is to capture and pass on the arguments
-        # to parent methods, which want to use them. This is one way. Another way
-        # is to declare the arguments explicitly. There's a software maintenance cost to that, though:
-        # if parameter changes are made to a ancestor method, it may require a change
-        # to the descendant methods.
-        super(ExampleLoggingApp, self).__init__(name='testloggingapp', syslog_facility='local0', *args, **kwargs)
+    def __init__(
+        self,
+        name,
+        parser=None,
+        logger=None,
+        lockfile=False,
+        syslog_facility=krux.cli.DEFAULT_LOG_FACILITY,
+        log_to_stdout=True,
+        parser_args=None,
+    ):
+        # The above method signature matches that of the parent, krux.cli.Application.__init__()
+        super(ExampleLoggingApp, self).__init__(
+            name=name,
+            parser=parser,
+            logger=logger,
+            lockfile=lockfile,
+            syslog_facility=syslog_facility,
+            log_to_stdout=log_to_stdout,
+            parser_args=parser_args,
+        )
 
     def run(self):
         """
@@ -36,8 +41,17 @@ class ExampleLoggingApp(krux.cli.Application):
 
 
 def main():
-    # instantiate your application class
-    app = ExampleLoggingApp()
+    # instantiate your application class.
+
+    # the 'name' parameter is just a string/name for your script. It should be unique in your environment,
+    # because stats will be emitted to statsd with that as part of the stat name.
+
+    # the syslog_facility parameter being set changes where logs get sent to;
+    # the default is to print them out to the console; setting a syslog facility
+    # means messages will go to syslog with the named facility and called severity;
+    # your local syslog config will need to route those messages to a file or remote syslog.
+
+    app = ExampleLoggingApp('testloggingapp', syslog_facility='local0')
 
     # app.context() makes sure the exceptions are logged, if any, exit hooks are handled (i.e. lock files),
     # and exit code is set properly.

--- a/example.py
+++ b/example.py
@@ -8,6 +8,9 @@ class ExampleLoggingApp(krux.cli.Application):
     This class gets a few things for free; not least of which:
       * a command-line option parser
       * a logger
+      * a stats dispatcher
+      * a context manager, which cleans up after us,
+        including deleting the lock file, if one was created.
     """
     def __init__(
         self,
@@ -30,10 +33,46 @@ class ExampleLoggingApp(krux.cli.Application):
             parser_args=parser_args,
         )
 
+        # If you have command line arguments, this is when you want
+        # to get retrieve & store them. super().__init__() will have stored them
+        # self.args for us. The only place we want to read from self.args
+        # is here in our __init__().
+        self.bit_bucket_kg = self.args.bit_bucket_kg
+        self.has_headlight_fluid = self.args.has_headlight_fluid
+
+        # Do any other initialization tasks here
+        pass
+
+    # If your app wants to add its own command line arguments, do it here.
+    # If not, then you don't need to create this method.
+    def add_cli_arguments(self, parser):
+        super(ExampleLoggingApp, self).add_cli_arguments(parser)
+
+        # See the docstring & comments in get_group()
+        group = krux.cli.get_group(self.parser, self.name)
+        # Build arguments as you would with ArgumentParser
+        # https://docs.python.org/2.7/library/argparse.html
+        group.add_argument(
+            '--bit-bucket-kg',
+            default=5,
+            help='Bit bucket weight in kg.',
+        )
+        group.add_argument(
+            '-f', '--has-headlight-fluid',
+            default=False,
+            action='store_true',
+            help='Contains sufficient headlight fluid.',
+        )
+
     def run(self):
         """
         Trivial example of calling at least one thing.
         """
+        print('The bit bucket weighs {} kg.'.format(self.bit_bucket_kg))
+        if self.has_headlight_fluid:
+            print('We have enough headlight fluid.')
+        else:
+            print('We could use more headlight fluid.')
         # the default log level is "warn" so you won't see these uness
         # you pass in --log-level from the command line
         self.logger.debug("this is a debug level message")

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.4-pre+dllopis.1'
+VERSION = '2.5.4'

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.3'
+VERSION = '2.5.4-pre+dllopis.1'

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -132,7 +132,7 @@ class Application(object):
         self.add_cli_arguments(self.parser)
 
         # and parse them
-        self.args = self.parser.parse_args(parser_args)
+        self.args = self.parser.parse_args(args=parser_args)
 
         # the cli facility should over-ride the passed-in syslog facility
         syslog_facility = self.args.syslog_facility

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -102,6 +102,7 @@ class Application(object):
         lockfile=False,
         syslog_facility=DEFAULT_LOG_FACILITY,
         log_to_stdout=True,
+        parser_args=None,
     ):
         """
         Wraps :py:class:`object` and sets up CLI argument parsing, stats and
@@ -112,6 +113,9 @@ class Application(object):
 
         :keyword parser: The CLI parser. Defaults to
         :py:func:`cli.get_parser <krux.cli.get_parser>`
+
+        :keyword list parser_args: List of argument strings to be fed to parser, or else None.
+        For testing purposes: Use to override the sys.argv command line arguments.
         """
 
         # note our name
@@ -128,7 +132,7 @@ class Application(object):
         self.add_cli_arguments(self.parser)
 
         # and parse them
-        self.args = self.parser.parse_args()
+        self.args = self.parser.parse_args(parser_args)
 
         # the cli facility should over-ride the passed-in syslog facility
         syslog_facility = self.args.syslog_facility

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -16,6 +16,7 @@ from time    import time
 
 import os
 import sys
+import copy
 
 #########################
 # Third Party Libraries #
@@ -298,6 +299,43 @@ class TestApplication(TestCase):
         )
 
         mock_logging.captureWarnings.assert_called_once_with(True)
+
+    def test_args(self):
+        """
+        krux.cli.Application gets args that match sys.argv (minus the name of the executable)
+        """
+        command_line_args = sys.argv[1:]
+        app = cli.Application(name=self.__class__.__name__)
+        _namespace, args = app.parser.parse_known_args()
+        self.assertEqual(args, command_line_args)
+
+
+class OverrideArgsApplication(cli.Application):
+    """
+    Used by TestOverrideArgsApplication.
+    """
+    def __init__(self, *args, **kwargs):
+        super(OverrideArgsApplication, self).__init__(*args, **kwargs)
+
+    def add_cli_arguments(self, parser):
+        super(OverrideArgsApplication, self).add_cli_arguments(parser)
+        group = cli.get_group(parser, 'test_group')
+        group.add_argument('--test-arg')
+
+
+class TestOverrideArgsApplication(TestCase):
+    def test_override_args(self):
+        """
+        krux.cli.Application gets the args we hand it, in lieu of the os.environ args
+        """
+        test_arg = '--test-arg'
+        test_value = 'test_value'
+        test_args = [test_arg, test_value]
+        test_attr = 'test_arg'
+        app = OverrideArgsApplication(name=self.__class__.__name__,
+                                      parser_args=test_args)
+        self.assertEqual(getattr(app.args, test_attr), test_value)
+
 
 ###
 ### Test krux.cli.Application


### PR DESCRIPTION
## What does this PR do?
**#### CHANGE PROPOSAL ####**
When instantiating a `krux.cli.Application`-based class, allow the user to provide their own arguments, overriding the process’ command-line arguments.
This adds a new parameter to `krux.cli.Application.init()`: `parser_args`.

## Why is this change being made?
To run unit tests and experiments on `krux.cli.Application`-based apps, it would helpful if we could override the command-line arguments that the app would normally get from `sys.argv`. This is functionality that `argparse.ArgumentParser` already supports, and since KruxParser is based on it, this requires changes to just two lines of code in `krux/cli.py`.
Since `cli.Application` relies heavily on command-line arguments, and since it consumes & processes those arguments on initialization, these arguments must be passed in to `__init__()`: it can’t be passed in later.

I added the `parser_args=None` parameter to `krux.cli.Application.__init__()`, which the passes that value to `self.parser.parse_args()`. Since `self.parser` is an inheritor of `ArgumentParser`, this will be a call to [ArgumentParser.parse_args(args=None, namespace=None)](https://docs.python.org/2/library/argparse.html#argparse.ArgumentParser.parse_args) .

I changed `example.com` so that `ExampleLoggingApp.__init__()` sends along `*args` & `**kwargs`. If it doesn’t, then the super class (`cli.Application`) won’t receive the `parse_args` parameter (nor other parameters that it should, like `parser`, `logger`, and `lockfile`).

## How was this tested? How can the reviewer verify your testing?
I added some unit tests, I ran all the unit tests, and I tested hand by, creating Application subclasses. I also tested it against @hanpeter’s branch that adds environment variable support.

## Where should the reviewer start?
`krux.cli.Application.__init__()`

## What gif best describes this PR or how it makes you feel?
![color-coded-display](https://user-images.githubusercontent.com/496931/32684518-0d126d8a-c639-11e7-912d-7102999efa3a.gif)

## Completion checklist
- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation has been updated.
- [x] Dependencies have been documented, deployed, and verified as
      appropriate.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] Large or high-impact changes have been canaried in the
      appropriate environment(s).