### PR TITLE
Bugfix for KruxParser.add_argument_group()

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '3.0.0'
+VERSION = '3.0.1'

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -228,6 +228,8 @@ class KruxParser(ArgumentParser):
         description = args[1] if len(args) > 1 else kwargs.pop('description', None)
         env_var_prefix = kwargs.pop('env_var_prefix', False)
 
+        # phan 2019-02-13: In order to use `KruxGroup` instead of `_ArgumentGroup`, I am purposely shadowing the super
+        #                  class' `add_argument_group()` method. All that work is copied into here.
         group = KruxGroup(container=self, title=title, description=description, env_var_prefix=env_var_prefix, **kwargs)
         self._action_groups.append(group)
         return group

--- a/krux/parser.py
+++ b/krux/parser.py
@@ -205,14 +205,14 @@ def get_group(parser, group_name, env_var_prefix=None):
 
 
 class KruxParser(ArgumentParser):
-    def add_argument_group(self, env_var_prefix, *args, **kwargs):
+    def add_argument_group(self, *args, **kwargs):
         """
         Creates a KruxGroup object that wraps the argparse._ArgumentGroup and creates a nice group of arguments
         that should be considered together.
 
         :param env_var_prefix: Prefix to use for the environment variables support of this group. If set to None,
-                               uses the title of the _ArgumentGroup that this is wrapping. If set to False,
-                               does not add any prefix.
+                               uses the title of the _ArgumentGroup that this is wrapping. If not set or set to False,
+                               does not add any prefix. This argument MUST be a keyword argument.
         :type env_var_prefix: str | bool
         :param args: Ordered arguments passed directly to argparse._ArgumentGroup.__init__()
         :type args: list
@@ -221,7 +221,14 @@ class KruxParser(ArgumentParser):
         :return: The created KruxGroup object
         :rtype: krux.parser.KruxGroup
         """
-        group = KruxGroup(env_var_prefix=env_var_prefix, container=self, *args, **kwargs)
+        # XXX: `title` and `description` are `_ArgumentGroup.__init__()`'s arguments. Sometimes, they come in as
+        #      positional arguments. `KruxParser` must support that behaviour. Thus, we merge the two behaviours here.
+        # XXX: Use `dict.pop()` so that we don't pass these twice.
+        title = args[0] if len(args) > 0 else kwargs.pop('title', None)
+        description = args[1] if len(args) > 1 else kwargs.pop('description', None)
+        env_var_prefix = kwargs.pop('env_var_prefix', False)
+
+        group = KruxGroup(container=self, title=title, description=description, env_var_prefix=env_var_prefix, **kwargs)
         self._action_groups.append(group)
         return group
 
@@ -230,7 +237,7 @@ class KruxGroup(_ArgumentGroup):
     HELP_ENV_VAR = "(env: {key})"
     HELP_DEFAULT = "(default: {default})"
 
-    def __init__(self, env_var_prefix=None, *args, **kwargs):
+    def __init__(self, env_var_prefix=False, **kwargs):
         """
         Creates a wrapper around argparse._ArgumentGroup that handles some help doc automation as well as environment
         variable fall back
@@ -244,7 +251,7 @@ class KruxGroup(_ArgumentGroup):
         :type kwargs: dict
         """
         # Call to the superclass to bootstrap.
-        super(KruxGroup, self).__init__(*args, **kwargs)
+        super(KruxGroup, self).__init__(**kwargs)
 
         if env_var_prefix:
             self._env_prefix = str(env_var_prefix) + '_'

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -324,12 +324,12 @@ class KruxParserTest(unittest.TestCase):
         krux.parser.KruxParser.add_argument_group() correctly creates and returns a KruxGroup object when positional arguments are used
         """
 
-        group = self._parser.add_argument_group(self.FAKE_TITLE, self.FAKE_DESCRIPTION, self.FAKE_ENV_VAR_PREFIX)
+        group = self._parser.add_argument_group(self.FAKE_TITLE, self.FAKE_DESCRIPTION)
 
         # Check whether the return value is correct
         self.assertEqual(self.FAKE_TITLE, group.title)
         self.assertEqual(self.FAKE_DESCRIPTION, group.description)
-        self.assertEqual(self.FAKE_ENV_VAR_PREFIX + '_', group._env_prefix)
+        self.assertEqual(self.FAKE_TITLE + '_', group._env_prefix)
 
         # Check whether the KruxGroup object was added to the list
         self.assertIn(group, self._parser._action_groups)

--- a/tests/unit_tests/test_parser.py
+++ b/tests/unit_tests/test_parser.py
@@ -296,31 +296,43 @@ class AddTest(unittest.TestCase):
 
 
 class KruxParserTest(unittest.TestCase):
+    FAKE_TITLE = 'fake-title'
+    FAKE_DESCRIPTION = 'fake-description'
+    FAKE_ENV_VAR_PREFIX = 'FAKE'
+
     def setUp(self):
         self._parser = KruxParser()
 
-    @patch('krux.parser.KruxGroup')
-    def test_add_argument_group(self, mock_group_class):
+    def test_add_argument_group_keyword(self):
         """
-        krux.parser.KruxParser.add_argument_group() correctly creates and returns a KruxGroup object
+        krux.parser.KruxParser.add_argument_group() correctly creates and returns a KruxGroup object when keyword arguments are used
         """
-        env_var_prefix = False
-        title = 'fake-title'
-
-        group = self._parser.add_argument_group(env_var_prefix=env_var_prefix, title=title)
-
-        # Check whether the return value is correct
-        self.assertEqual(mock_group_class.return_value, group)
-
-        # Check whether the KruxGroup object was created correctly
-        mock_group_class.assert_called_once_with(
-            env_var_prefix=env_var_prefix,
-            container=self._parser,
-            title=title,
+        group = self._parser.add_argument_group(
+            env_var_prefix=self.FAKE_ENV_VAR_PREFIX, title=self.FAKE_TITLE, description=self.FAKE_DESCRIPTION
         )
 
+        # Check whether the return value is correct
+        self.assertEqual(self.FAKE_TITLE, group.title)
+        self.assertEqual(self.FAKE_DESCRIPTION, group.description)
+        self.assertEqual(self.FAKE_ENV_VAR_PREFIX + '_', group._env_prefix)
+
         # Check whether the KruxGroup object was added to the list
-        self.assertIn(mock_group_class.return_value, self._parser._action_groups)
+        self.assertIn(group, self._parser._action_groups)
+
+    def test_add_argument_group_positional(self):
+        """
+        krux.parser.KruxParser.add_argument_group() correctly creates and returns a KruxGroup object when positional arguments are used
+        """
+
+        group = self._parser.add_argument_group(self.FAKE_TITLE, self.FAKE_DESCRIPTION, self.FAKE_ENV_VAR_PREFIX)
+
+        # Check whether the return value is correct
+        self.assertEqual(self.FAKE_TITLE, group.title)
+        self.assertEqual(self.FAKE_DESCRIPTION, group.description)
+        self.assertEqual(self.FAKE_ENV_VAR_PREFIX + '_', group._env_prefix)
+
+        # Check whether the KruxGroup object was added to the list
+        self.assertIn(group, self._parser._action_groups)
 
 
 class KruxGroupTest(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where `KruxParser.add_argument_group()` throws an error when positional arguments are used. This was found when `parser.add_subparsers()` method was used because `argparse` internally calls `parser.add_argument_group(title, description)`.

## Why is this change being made?

This is a bug fix.

## How was this tested? How can the reviewer verify your testing?

A unit test to cover this case is written. The test correctly failed before the fix with the same symptom. The test passed after the fix.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/3rYxjO5uI5XKWfekns/giphy.gif)

## Completion checklist

- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).