### PR TITLE
stats compatibility

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '3.0.1'
+VERSION = '3.1.0'

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -257,7 +257,7 @@ class TestApplication(TestCase):
         with self.assertRaises(cli.CriticalApplicationError):
             try:
                 raise StandardError('Test Error')
-            except Exception, e:
+            except Exception as e:
                 app.raise_critical_error(e)
 
         mock_hook.assert_called_once_with()

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -78,15 +78,15 @@ def test_get_parser():
     parser = cli.get_parser()
     assert_true(parser)
 
+
 def test_get_script_name():
     """
     Test getting script name from the invoking script
     """
     name = cli.get_script_name()
 
-    ### these tests are invoked as 'nosetests --options...', so
-    ### that's the name of the 'script'
-    assert_equal(name, 'nosetests')
+    assert_equal(name, os.path.basename(sys.argv[0]))
+
 
 class TestApplication(TestCase):
 

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -37,7 +37,7 @@ def test_get_stats():
 
 def test_get_dummy_stats():
     """
-    Test getting a fakse stats object from krux.stats
+    Test getting a false stats object from krux.stats
     """
     stats = krux.stats.get_stats(prefix='dummy_app', client=False)
 
@@ -51,7 +51,7 @@ def test_get_legacy_client():
     Test that a 'legacy' stats client is returned when requested
     """
 
-    stats = krux.stats.get_stats(prefix='dummy_app', client='legacy')
+    stats = krux.stats.get_stats(prefix='dummy_app', legacy_names=True)
     assert_true(isinstance(stats, kruxstatsd.StatsClient))
 
 

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -12,9 +12,7 @@ __author__ = 'Jos Boumans'
 # Third Party Libraries #
 #########################
 
-from mock       import patch, call
 from nose.tools import assert_true, assert_false
-from pprint     import pprint
 
 ######################
 # Internal Libraries #
@@ -23,15 +21,17 @@ import krux.stats
 
 from krux.stats import DummyStatsClient
 
+
 def test_get_stats():
     """
     Test getting a stats object from krux.stats
     """
     stats = krux.stats.get_stats(prefix = 'real_app')
 
-    ### object, and of the right class?
+    # object, and of the right class?
     assert_true(stats)
     assert_false(isinstance(stats, DummyStatsClient))
+
 
 def test_get_dummy_stats():
     """
@@ -39,8 +39,6 @@ def test_get_dummy_stats():
     """
     stats = krux.stats.get_stats(prefix = 'dummy_app', client = False)
 
-    ### object, and of the right class?
+    # object, and of the right class?
     assert_true(stats)
     assert_true(isinstance(stats, DummyStatsClient))
-
-

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -20,13 +20,15 @@ from nose.tools import assert_true, assert_false
 import krux.stats
 
 from krux.stats import DummyStatsClient
+import kruxstatsd
+import statsd
 
 
 def test_get_stats():
     """
     Test getting a stats object from krux.stats
     """
-    stats = krux.stats.get_stats(prefix = 'real_app')
+    stats = krux.stats.get_stats(prefix='dummy_app')
 
     # object, and of the right class?
     assert_true(stats)
@@ -37,8 +39,25 @@ def test_get_dummy_stats():
     """
     Test getting a fakse stats object from krux.stats
     """
-    stats = krux.stats.get_stats(prefix = 'dummy_app', client = False)
+    stats = krux.stats.get_stats(prefix='dummy_app', client=False)
 
     # object, and of the right class?
     assert_true(stats)
     assert_true(isinstance(stats, DummyStatsClient))
+
+
+def test_get_legacy_client():
+    """
+    Test that a 'legacy' stats client is returned when requested
+    """
+
+    stats = krux.stats.get_stats(prefix='dummy_app', client='legacy')
+    assert_true(isinstance(stats, kruxstatsd.StatsClient))
+
+
+def test_get_default_client():
+    """
+    Test that the default is to return a bare statsd.StatsClient
+    """
+    stats = krux.stats.get_stats(prefix='dummy_app')
+    assert_true(isinstance(stats, statsd.StatsClient))


### PR DESCRIPTION
# What does this PR do?

Changes the default behaviour of the stats client to no longer include the host and environment names. Projects including this code can request the `legacy` mode and get the old behaviour if desired.

# Why is this change being made?

Krux is moving away from graphite and towards a service. That service aggregates stats by tags, and does not permit the use wildcards in stat names in the UI.

This means that the stats we send currently have to be run through a rewrite proxy, to remove the host and environment names. This change makes that no longer necessary, and permits us to (eventually!) remove the rewriting proxy on each host.

# What else?

Fixed a test that only worked when run via `nosetests`, which has been deprecated, and which IDEs no longer commonly use.

# How was this tested?

This is a WIP, so testing so far has been light.

* unit tests have been updated
* cursory local tests via another Krux project