### PR TITLE
Fix python_requires

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '3.1.1'
+VERSION = '3.1.2'

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
         'mock',
         'nose',
     ],
-    python_requires='~=2.7, ~=3.6',
+    python_requires='<4',
 )


### PR DESCRIPTION
Setting `python_requires='<4'` in `setup.py` will effectively support any version of `2.7.*` and any version of 3. Technically, it claims to support versions less than 2.7, but at this point we don’t care.