### PR TITLE
Pass lockfile to get_parser

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,5 +23,6 @@ coverage = { version="*", index="pypi" }
 mock = { version="*", index="pypi" }
 nose = { version="*", index="pypi" }
 
-[requires]
-python_version = "3.6"
+# These are needed for 2/3 compatibility
+funcsigs = { version="*", index="pypi" }
+subprocess32 = { version="*", index="pypi" }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b42b9995b9749a631d2cff2c7c5f9ca8f76890c4235bc79738e6e09d6354886"
+            "sha256": "6673e94bceef4f99c5ae9b469efebab66ca8e27008bc23fd0b597d6b35932d75"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "kruxfoss",
@@ -192,10 +190,9 @@
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128",
-                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
+                "sha256:9f3b9ffe0809d174f7047e121431acf99c89a7040f0ca84f94ba53a498e6d0c9"
             ],
-            "version": "==1.2.1"
+            "version": "==1.9.0"
         },
         "sphinx": {
             "hashes": [
@@ -218,6 +215,15 @@
                 "sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f"
             ],
             "version": "==3.3.0"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:38566c558a0a94d6531012c8e917b1b8518a41e418f7f15f00e129cc80162ad3",
+                "sha256:53765ec4f83a2b720214727e319607879fec4acde22c4fbb54fa2604e79e44ce",
+                "sha256:84698954b4e6719e912ef9a42a2431407fe3755590831699debda6fba92aac55"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==3.7.4"
         },
         "urllib3": {
             "hashes": [
@@ -265,6 +271,15 @@
             "index": "pypi",
             "version": "==4.5.3"
         },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "index": "pypi",
+            "markers": null,
+            "version": "==1.0.2"
+        },
         "mock": {
             "hashes": [
                 "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3",
@@ -288,6 +303,14 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "subprocess32": {
+            "hashes": [
+                "sha256:88e37c1aac5388df41cc8a8456bb49ebffd321a3ad4d70358e3518176de3a56b",
+                "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"
+            ],
+            "index": "pypi",
+            "version": "==3.5.4"
         }
     }
 }

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '3.1.2'
+VERSION = '3.2.0'

--- a/krux/cli.py
+++ b/krux/cli.py
@@ -119,7 +119,11 @@ class Application(object):
         # Since this is a functional interface, we pass along whether or not stdout logging is desired
         # for a particular subclass/script
         #
-        self.parser = parser or get_parser(description=name, logging_stdout_default=log_to_stdout)
+        self.parser = parser or get_parser(
+            description=name,
+            lockfile=lockfile,
+            logging_stdout_default=log_to_stdout,
+        )
 
         # get more arguments, if needed
         self.add_cli_arguments(self.parser)


### PR DESCRIPTION
## What does this PR do

When [`cli.Application`](https://github.com/krux/python-krux-stdlib/blob/0f11a25fdf267c3d577aae2f881eefbcac4a3b89/krux/cli.py#L81) is called with [`lockfile = False`](https://github.com/krux/python-krux-stdlib/blob/0f11a25fdf267c3d577aae2f881eefbcac4a3b89/krux/cli.py#L95), it properly does not attempt to acquire a lock, but it still includes the `--lock-dir` flag, because [`get_parser`](https://github.com/krux/python-krux-stdlib/blob/0f11a25fdf267c3d577aae2f881eefbcac4a3b89/krux/parser.py#L30) is not being passed [`lockfile`](https://github.com/krux/python-krux-stdlib/blob/0f11a25fdf267c3d577aae2f881eefbcac4a3b89/krux/cli.py#L122).

## How was it tested

I updated the `Pipfile` to not require a specific python version, then created a virtualenv for `2.7.14`, and `3.6.9`, then ran `nosetests`. Everything was a success.