### PR TITLE
W-6690988: Migrate over to pytest

### DIFF
--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '4.0.0'
+VERSION = '4.0.1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,12 @@
 [metadata]
 description-file = README.md
 
+[aliases]
+# Use pytest for testing locally:
+test = pytest
+# And also for Continuous Integration tests:
+citest = test
+
 [nosetests]
 cover-branches = 1
 cover-html = 1
@@ -11,4 +17,4 @@ with-coverage = 1
 with-id = 1
 
 [flake8]
-max-line-length = 80
+max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,12 @@ test = pytest
 # And also for Continuous Integration tests:
 citest = test
 
+[tool:pytest]
+# Options for pytest
+# Adds following CLI options whenever pytest is triggered
+addopts =
+    --cov krux
+
 [nosetests]
 cover-branches = 1
 cover-html = 1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
     # For Python 2.*, install the backported subprocess
     REQUIREMENTS.append('subprocess32')
 
-TEST_REQUIREMENTS = ['coverage', 'mock', 'nose', 'pytest', 'pytest-cov']
+TEST_REQUIREMENTS = ['coverage', 'mock', 'nose', 'pytest', 'pytest-cov', 'pytest-runner']
 
 LINT_REQUIREMENTS = ['flake8']
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
     # For Python 2.*, install the backported subprocess
     REQUIREMENTS.append('subprocess32')
 
-TEST_REQUIREMENTS = ['coverage', 'mock', 'nose']
+TEST_REQUIREMENTS = ['coverage', 'mock', 'nose', 'pytest', 'pytest-cov']
 
 LINT_REQUIREMENTS = ['flake8']
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -79,9 +79,10 @@ def test_get_script_name():
     """
     Test getting script name from the invoking script
     """
-    name = cli.get_script_name()
+    script_name = cli.get_script_name()
+    command = os.path.basename(sys.argv[0]).replace('.py', '')
 
-    assert_equal(name, os.path.basename(sys.argv[0]))
+    assert_equal(script_name, command)
 
 
 class TestApplication(TestCase):

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -238,6 +238,7 @@ class TestApplication(TestCase):
 
         assert_true(mock_logger.exception.called)
 
+    @patch('sys.argv', ['test-app'])
     def test_raise_critical_error(self):
         """
         krux.cli.Application executes the exit hooks, logs, and wraps the error as CriticalApplicationError upon raise_critical_error call
@@ -297,6 +298,7 @@ class TestApplication(TestCase):
 
         mock_logging.captureWarnings.assert_called_once_with(True)
 
+    @patch('sys.argv', ['test-app'])
     def test_args(self):
         """
         krux.cli.Application gets args that match sys.argv (minus the name of the executable)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -5,32 +5,29 @@
 """
 Unit tests for the krux.cli module.
 """
-######################
+#
 # Standard Libraries #
-######################
+#
 from __future__ import absolute_import
 from unittest import TestCase
-
 from logging import Logger
-from time    import time
-
+from time import time
 import os
 import sys
 
-#########################
+#
 # Third Party Libraries #
-#########################
+#
 from argparse import ArgumentParser, Namespace
 from builtins import str
 from mock import MagicMock, patch
 from nose.tools import assert_equal, assert_true
 
-######################
+#
 # Internal Libraries #
-######################
-from krux.stats     import DummyStatsClient
-from krux.logging   import DEFAULT_LOG_LEVEL
-
+#
+from krux.stats import DummyStatsClient
+from krux.logging import DEFAULT_LOG_LEVEL
 import krux.cli as cli
 
 
@@ -38,10 +35,10 @@ def test_get_new_group():
     """
     Getting an argument group that doesn't exist.
     """
-    name                           = 'new_group'
-    mock_parser                    = MagicMock(spec=ArgumentParser)
-    mock_parser._action_groups     = []
-    mock_parser.add_argument_group = MagicMock(return_value = name)
+    name = 'new_group'
+    mock_parser = MagicMock(spec=ArgumentParser)
+    mock_parser._action_groups = []
+    mock_parser.add_argument_group = MagicMock(return_value=name)
 
     group = cli.get_group(mock_parser, name)
 
@@ -53,10 +50,10 @@ def test_get_existing_group():
     """
     Getting an argument group that already exists.
     """
-    name                       = 'existing'
-    mock_group                 = MagicMock()
-    mock_group.title           = name
-    mock_parser                = MagicMock(spec=ArgumentParser)
+    name = 'existing'
+    mock_group = MagicMock()
+    mock_group.title = name
+    mock_parser = MagicMock(spec=ArgumentParser)
     mock_parser._action_groups = [mock_group]
 
     group = cli.get_group(mock_parser, name)
@@ -65,11 +62,11 @@ def test_get_existing_group():
     assert_equal(group, mock_group)
 
 
-### XXX autospecing ArgumentParser does not autospec the private method
-### we are (ab)using in krux.cli. So for now, just do the simplest test
-### possible
+# XXX autospecing ArgumentParser does not autospec the private method
+# we are (ab)using in krux.cli. So for now, just do the simplest test
+# possible
 
-#@patch('krux.cli.ArgumentParser', autospec=True)
+# @patch('krux.cli.ArgumentParser', autospec=True)
 def test_get_parser():
     """
     Test getting a parser from krux.cli
@@ -159,7 +156,6 @@ class TestApplication(TestCase):
             action='version',
             version=' '.join([self.app.name, version]),
         )
-
 
     @patch('krux.cli.krux.logging.get_logger')
     def test_syslog_facility(self, mock_logger):
@@ -338,45 +334,46 @@ class TestOverrideArgsApplication(TestCase):
         self.assertEqual(getattr(app.args, test_attr), test_value)
 
 
-###
-### Test krux.cli.Application
-###
+#
+# Test krux.cli.Application
+#
 
 def test_application():
     """
     Test getting an Application from krux.cli
     """
 
-    ### Vanilla app
+    # Vanilla app
     with patch('sys.argv', [__name__]):
-        app = cli.Application(name = __name__)
+        app = cli.Application(name=__name__)
     assert_true(app)
     assert_true(app.parser)
     assert_true(app.stats)
     assert_true(app.logger)
 
+
 def test_application_locks():
-    ### just to make sure stale runs don't interfere
+    # just to make sure stale runs don't interfere
     name = __name__ + str(time())
 
-    ### Now with lockfile
+    # Now with lockfile
     with patch('sys.argv', [__name__]):
-        app = cli.Application(name = name, lockfile = True)
+        app = cli.Application(name=name, lockfile=True)
 
         assert_true(app)
         assert_true(app.lockfile)
 
-        ### This will use the same lockfile, as it's based on pid.
-        ### so this should work
-        app = cli.Application(name = name, lockfile = True)
+        # This will use the same lockfile, as it's based on pid.
+        # so this should work
+        app = cli.Application(name=name, lockfile=True)
         assert_true(app)
         assert_true(app.lockfile)
 
-        ### needed to clean up lock file, or /tmp will get littered.
+        # needed to clean up lock file, or /tmp will get littered.
         app._run_exit_hooks()
 
-        ### XXX ideally we'd have a failure test in here as well, but
-        ### because of the way it's implemented LockFile won't fail if the
-        ### same pid tries to get the same lock twice:
-        ### http://pydoc.net/Python/lockfile/0.9.1/lockfile.linklockfile/
-        ### suggestions welcome!
+        # XXX ideally we'd have a failure test in here as well, but
+        # because of the way it's implemented LockFile won't fail if the
+        # same pid tries to get the same lock twice:
+        # http://pydoc.net/Python/lockfile/0.9.1/lockfile.linklockfile/
+        # suggestions welcome!

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -5,13 +5,12 @@
 """
 Unit tests for the krux.io module.
 """
-######################
+#
 # Standard Libraries #
-######################
+#
 from __future__ import absolute_import
 from unittest import TestCase
 from logging import Logger
-
 import re
 import shutil
 import tempfile
@@ -19,9 +18,9 @@ import signal
 import os
 import sys
 
-#########################
+#
 # Third Party Libraries #
-#########################
+#
 from nose.tools import assert_equal, assert_true, assert_false, raises
 from mock import MagicMock, patch, call
 if os.name == 'posix' and sys.version_info[0] < 3:
@@ -30,10 +29,9 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
     import subprocess
 
-######################
+#
 # Internal Libraries #
-######################
-
+#
 import krux.io
 
 
@@ -71,24 +69,24 @@ class TestApplication(TestCase):
 
     def test_cmd_true(self):
         """ Test return code from successful command """
-        cmd = self.io.run_cmd( command = 'true' )
+        cmd = self.io.run_cmd(command='true')
 
         assert_true(cmd.ok)
         assert_equal(cmd.returncode, 0)
 
-        ### additional tests, just so we have 'm at least once
+        # additional tests, just so we have 'm at least once
         assert_equal(cmd.command, 'true')
 
     def test_cmd_as_list(self):
         """ Commands can be provided as a list """
-        cmd = self.io.run_cmd( command = ['true'] )
+        cmd = self.io.run_cmd(command=['true'])
 
         assert_true(cmd.ok)
         assert_equal(cmd.returncode, 0)
 
     def test_cmd_false(self):
         """ Test return code from failing command """
-        cmd = self.io.run_cmd( command = 'false' )
+        cmd = self.io.run_cmd(command='false')
 
         assert_false(cmd.ok)
         assert_equal(cmd.returncode, 1)
@@ -96,11 +94,11 @@ class TestApplication(TestCase):
     @raises(krux.io.RunCmdError)
     def test_cmd_exception(self):
         """ Test we can raise exceptions """
-        cmd = self.io.run_cmd( command = 'false', raise_exception = True )
+        cmd = self.io.run_cmd(command='false', raise_exception=True)
 
     def test_cmd_stdout(self):
         """ Make sure we can capture stdout """
-        cmd = self.io.run_cmd( command = 'echo 42' )
+        cmd = self.io.run_cmd(command='echo 42')
 
         assert_true(cmd.ok)
         assert_equal(cmd.returncode, 0)
@@ -109,8 +107,8 @@ class TestApplication(TestCase):
     def test_cmd_filters(self):
         """ Strip out parts of the output, based on filters """
 
-        filter = re.compile( '\d+' )
-        cmd    = self.io.run_cmd( command = 'echo 42', filters = [ filter ] )
+        filter = re.compile(r'\d+')
+        cmd = self.io.run_cmd(command='echo 42', filters=[filter])
 
         assert_true(cmd.ok)
         assert_equal(cmd.returncode, 0)
@@ -119,15 +117,15 @@ class TestApplication(TestCase):
     def test_broken_input(self):
         """ Commands must be strings/buffers, not objects - test for exceptions """
 
-        cmd = self.io.run_cmd( command = self )
+        cmd = self.io.run_cmd(command=self)
 
-        ### parsing failed, so the command is not ok, but there's no return
-        ### code set for it, but exceptions are filled
+        # parsing failed, so the command is not ok, but there's no return
+        # code set for it, but exceptions are filled
         assert_false(cmd.ok)
         assert_true(cmd.exception)
         assert_equal(cmd.returncode, krux.io.RUN_COMMAND_EXCEPTION_EXIT_CODE)
 
-        ### but these are all not set
+        # but these are all not set
         assert_false(len(cmd.stdout))
         assert_false(len(cmd.stderr))
 
@@ -155,9 +153,9 @@ class TestApplication(TestCase):
         with patch('krux.io.subprocess.Popen', mock_popen):
             self.io = krux.io.IO(logger=mock_logger)
             cmd = self.io.run_cmd(
-                command = self.TIMEOUT_COMMAND,
-                timeout = self.TIMEOUT_SECOND,
-                timeout_terminate_signal = self.TIMEOUT_COMMAND
+                command=self.TIMEOUT_COMMAND,
+                timeout=self.TIMEOUT_SECOND,
+                timeout_terminate_signal=self.TIMEOUT_COMMAND
             )
 
             # Check to make sure the command has failed with expected exception
@@ -167,8 +165,8 @@ class TestApplication(TestCase):
             assert_equal(cmd.returncode, krux.io.RUN_COMMAND_EXCEPTION_EXIT_CODE)
 
         # Check to make sure error handling is done correctly and process is sent the given signal
-        mock_process.communicate.assert_has_calls( [ call( timeout = self.TIMEOUT_SECOND ), call() ] )
-        mock_process.send_signal.assert_called_once_with( self.TIMEOUT_COMMAND )
+        mock_process.communicate.assert_has_calls([call(timeout=self.TIMEOUT_SECOND), call()])
+        mock_process.send_signal.assert_called_once_with(self.TIMEOUT_COMMAND)
 
         # Check to make sure the error is logged
         mock_logger.critical.assert_called_once_with('Command failed: %s', timeout_error)

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -45,7 +45,9 @@ def test_get_logger_all():
     """
     with patch('krux.logging.setup') as mock_setup:
         with patch('krux.logging.syslog_setup') as mock_syslog_setup:
-            krux.logging.get_logger(TEST_LOGGER_NAME, syslog_facility=krux.logging.DEFAULT_LOG_FACILITY, log_to_stdout=True, foo='bar')
+            krux.logging.get_logger(
+                TEST_LOGGER_NAME, syslog_facility=krux.logging.DEFAULT_LOG_FACILITY, log_to_stdout=True, foo='bar'
+            )
 
     mock_setup.assert_called_once_with(foo='bar')
     mock_syslog_setup.assert_called_once_with(TEST_LOGGER_NAME, krux.logging.DEFAULT_LOG_FACILITY, foo='bar')

--- a/tests/unit_tests/test_object.py
+++ b/tests/unit_tests/test_object.py
@@ -23,7 +23,7 @@ from mock import MagicMock, patch
 from krux.object import Object
 
 
-class TestObject(Object):
+class DummyObject(Object):
     """
     Just needed a subclass of Object for unit test.
     Nothing to see here. Move along.
@@ -69,6 +69,6 @@ class ObjectTest(unittest.TestCase):
         """
         The default value of _name property for a subclass is handled correctly
         """
-        app = TestObject()
+        app = DummyObject()
 
-        self.assertEqual(TestObject.__name__, app._name)
+        self.assertEqual(DummyObject.__name__, app._name)

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -8,17 +8,15 @@ Unit tests for the krux.stats module.
 from __future__ import absolute_import
 __author__ = 'Jos Boumans'
 
-#########################
+#
 # Third Party Libraries #
-#########################
-
+#
 from nose.tools import assert_true, assert_false
 
-######################
+#
 # Internal Libraries #
-######################
+#
 import krux.stats
-
 from krux.stats import DummyStatsClient
 import kruxstatsd
 import statsd

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -5,22 +5,21 @@
 """
 Tests for the krux.util module.
 """
-######################
+#
 # Standard Libraries #
-######################
+#
 from __future__ import absolute_import
-
 import unittest
 
-#########################
+#
 # Third Party Libraries #
-#########################
+#
 from builtins import object
 from nose.tools import assert_false, assert_true
 
-######################
+#
 # Internal Libraries #
-######################
+#
 from krux.util import hasmethod, flatten
 
 

--- a/tests/unit_tests/test_wrapper.py
+++ b/tests/unit_tests/test_wrapper.py
@@ -24,7 +24,7 @@ from mock import MagicMock, call
 from krux.wrapper import Wrapper
 
 
-class TestWrapper(Wrapper):
+class DummyWrapper(Wrapper):
     z = 3
 
     def _get_wrapper_function(self, func):
@@ -35,7 +35,7 @@ class TestWrapper(Wrapper):
         return wrap
 
 
-class TestObject(object):
+class DummyObject(object):
     x = 1
 
     def y(self, value):
@@ -48,9 +48,9 @@ class WrapperTest(unittest.TestCase):
         self._logger = MagicMock()
         self._stats = MagicMock()
 
-        self._object = TestObject()
+        self._object = DummyObject()
 
-        self._wrapper = TestWrapper(
+        self._wrapper = DummyWrapper(
             wrapped=self._object,
             logger=self._logger,
             stats=self._stats,
@@ -66,7 +66,7 @@ class WrapperTest(unittest.TestCase):
         """
         krux.wrapper.Wrapper correctly returns the value of the wrapper's property
         """
-        self.assertEqual(TestWrapper.z, self._wrapper.z)
+        self.assertEqual(DummyWrapper.z, self._wrapper.z)
         self.assertFalse(self._logger.debug.called)
 
     def test_wrapped_property(self):


### PR DESCRIPTION
## What does this PR do?

This PR updates the library so it can be tested in our CI using `pytest`.

## Why is this change being made?

We do not want to use the old `nosetests` anymore.

## How was this tested? How can the reviewer verify your testing?

```bash
$ python -m setup citest
running pytest
running egg_info
writing krux_stdlib.egg-info/PKG-INFO
writing dependency_links to krux_stdlib.egg-info/dependency_links.txt
writing requirements to krux_stdlib.egg-info/requires.txt
writing top-level names to krux_stdlib.egg-info/top_level.txt
reading manifest file 'krux_stdlib.egg-info/SOURCES.txt'
writing manifest file 'krux_stdlib.egg-info/SOURCES.txt'
running build_ext
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.7.4, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
rootdir: /Users/phan/projects/python-krux-stdlib, inifile: setup.cfg
plugins: cov-2.8.1
collected 77 items

tests/unit_tests/test_cli.py .....................                                                                                                                           [ 27%]
tests/unit_tests/test_io.py .............                                                                                                                                    [ 44%]
tests/unit_tests/test_logging.py ..                                                                                                                                          [ 46%]
tests/unit_tests/test_object.py ...                                                                                                                                          [ 50%]
tests/unit_tests/test_parser.py ......................                                                                                                                       [ 79%]
tests/unit_tests/test_stats.py ....                                                                                                                                          [ 84%]
tests/unit_tests/test_util.py .......                                                                                                                                        [ 93%]
tests/unit_tests/test_wrapper.py .....                                                                                                                                       [100%]

---------- coverage: platform darwin, python 3.7.4-final-0 -----------
Name                Stmts   Miss  Cover
---------------------------------------
krux/__init__.py        1      1     0%
krux/cli.py           104     17    84%
krux/constants.py       7      0   100%
krux/io.py             97      9    91%
krux/logging.py        33      1    97%
krux/mail.py           40     40     0%
krux/object.py         11      0   100%
krux/parser.py         83      0   100%
krux/stats.py          26      2    92%
krux/util.py           18      4    78%
krux/wrapper.py        18      1    94%
---------------------------------------
TOTAL                 438     75    83%


================================================================================ 77 passed in 0.64s ================================================================================
```

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/SQiQu6lbG8bn2/giphy.gif)

## Completion checklist

- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Stakeholders have been notified. Workflow-impacting changes have been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).