### PR TITLE
upgrade pystache to 0.6.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,7 +24,7 @@ pytest-runner  = "~=5.2"
 [packages]
 kruxstatsd = {version = "~=0.3", source = "kruxfoss"}
 lockfile = "~=0.12"
-pystache = "~=0.5"
+pystache = "~=0.6.0"
 
 [requires]
 python_version = "3.6"

--- a/krux/__init__.py
+++ b/krux/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '5.0.0'
+VERSION = '5.0.1'


### PR DESCRIPTION
## What does this PR do?

Upgrades the version of pystache used for testing to ~=0.6.0.

## Why is this change being made?

Breaking builds.

## How does this PR do it?

Self-evident.

## How was this tested? How can the reviewer verify your testing?

As-yet untested. My laptop’s Python env. is totally borked right now, so I’m using CloudBees to test for me.

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `Pipfile` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).